### PR TITLE
Integrate GPD MCP servers for physics-first hypothesis ranking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,24 @@ Each phase: fan-out agents with `asyncio.gather()` → collect reports → `Deba
 ### Concurrency
 Fitting agents are rate-limited by `asyncio.Semaphore(config.fitting_semaphore_limit)` (default 6) to avoid overwhelming the API when `fitting_scope="per_hypothesis"` spawns `N_hypotheses × M` concurrent agents.
 
+### GPD MCP Integration
+MTF optionally connects to [get-physics-done](https://github.com/FaroutYLq/get-physics-done) MCP servers for physics verification. Install with `pip install -e ".[dev,gpd]"`. Controlled by `config.enable_gpd_mcp` (default `True`; no-ops gracefully if the package is missing).
+
+**Servers** (defined in `mtf/tools/gpd_mcp.py`):
+- `verification` — structured physics checks (dimensional analysis 5.1, symmetry 5.2, limiting cases 5.3, fit-family mismatch 5.18)
+- `errors` — catalog of 104 known physics error classes with detection strategies
+- `protocols` — canonical computation protocols (step-by-step methodology with checkpoints)
+- `conventions` — subfield-specific sign conventions, Fourier transforms, natural units
+- `patterns` — persistent cross-session library of discovered physics error patterns
+
+**`GPDMCPClient`** runs a dedicated background event loop in a daemon thread. Each server is a subprocess communicating over stdio MCP protocol. `make_tool(server, tool_name, description)` returns an `sdk.Tool` (or `None` if unavailable), which phases filter into agent tool lists. `call(server, tool_name, **kwargs)` provides synchronous access for one-shot calls (e.g. seeding patterns at startup).
+
+**New `MemoryKind` values**:
+- `CONVENTIONS` — physics convention snapshot locked at the start of the literature phase; included in all agent prompt contexts
+- `PHYSICS_VERDICT` — structured check results from the verification server; injected into debate synthesis context
+
+**Pipeline flow**: conventions are locked once in the literature phase via `subfield_defaults`. All three agent types accept `gpd_tools: list | None` for backward compatibility. `DebateEngine.synthesize()` conditionally adds a physics-first ranking criterion to the system prompt for fitting and review phases (not literature). Conventions and physics verdicts from memory are appended to the user content block sent to the synthesis call.
+
 ## Key Invariants
 
 - All `HumanInterface` methods are async; never call `input()` directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ mtf/
 ├── tools/
 │   ├── arxiv_search.py     sdk.Tool wrapping arxiv.Client
 │   ├── semantic_search.py  sdk.Tool wrapping semanticscholar API
-│   └── fitting_tools.py    run_fitting_code() — exec-based sandboxed runner
+│   ├── fitting_tools.py    run_fitting_code() — exec-based sandboxed runner
+│   └── gpd_mcp.py          GPDMCPClient — bridges GPD MCP servers to sdk.Tool
 └── toolkit/
     └── registry.py         ToolkitRegistry — user-provided data arrays + model callables
 ```
@@ -51,6 +52,9 @@ mtf/
 ```bash
 # Install (editable + dev extras)
 pip install -e ".[dev]"
+
+# Install with GPD physics verification
+pip install -e ".[dev,gpd]"
 
 # Lint
 ruff check mtf tests
@@ -93,22 +97,35 @@ Each phase: fan-out agents with `asyncio.gather()` → collect reports → `Deba
 Fitting agents are rate-limited by `asyncio.Semaphore(config.fitting_semaphore_limit)` (default 6) to avoid overwhelming the API when `fitting_scope="per_hypothesis"` spawns `N_hypotheses × M` concurrent agents.
 
 ### GPD MCP Integration
-MTF optionally connects to [get-physics-done](https://github.com/FaroutYLq/get-physics-done) MCP servers for physics verification. Install with `pip install -e ".[dev,gpd]"`. Controlled by `config.enable_gpd_mcp` (default `True`; no-ops gracefully if the package is missing).
 
-**Servers** (defined in `mtf/tools/gpd_mcp.py`):
-- `verification` — structured physics checks (dimensional analysis 5.1, symmetry 5.2, limiting cases 5.3, fit-family mismatch 5.18)
-- `errors` — catalog of 104 known physics error classes with detection strategies
-- `protocols` — canonical computation protocols (step-by-step methodology with checkpoints)
-- `conventions` — subfield-specific sign conventions, Fourier transforms, natural units
-- `patterns` — persistent cross-session library of discovered physics error patterns
+**Design principle: use existing GPD tools rather than reimplementing physics verification.** GPD ([Get Physics Done](https://github.com/psi-oss/get-physics-done)) already ships 104 curated error classes, step-by-step protocols for 47+ physics domains, convention databases for 18 subfields, and structured verification checks — all exposed as callable MCP tools. mtf consumes these tools at runtime through a bridge layer rather than duplicating this physics knowledge in its own prompts or code.
 
-**`GPDMCPClient`** runs a dedicated background event loop in a daemon thread. Each server is a subprocess communicating over stdio MCP protocol. `make_tool(server, tool_name, description)` returns an `sdk.Tool` (or `None` if unavailable), which phases filter into agent tool lists. `call(server, tool_name, **kwargs)` provides synchronous access for one-shot calls (e.g. seeding patterns at startup).
+Install with `pip install -e ".[dev,gpd]"`. Controlled by `config.enable_gpd_mcp` (default `True`; no-ops gracefully if the package is missing).
 
-**New `MemoryKind` values**:
-- `CONVENTIONS` — physics convention snapshot locked at the start of the literature phase; included in all agent prompt contexts
+**Servers** (managed by `GPDMCPClient` in `mtf/tools/gpd_mcp.py`):
+
+| Server | GPD tools used by mtf | Why mtf uses GPD instead of reimplementing |
+|---|---|---|
+| `verification` | `get_checklist`, `run_check`, `dimensional_check`, `limiting_case_check` | GPD maintains domain-specific checklists (check IDs 5.1–5.19) with automated issue detection. Reimplementing would require encoding physics knowledge per domain. |
+| `errors` | `check_error_classes`, `get_detection_strategy` | GPD's catalog of 104 error classes (sign errors, missing factors of 2π, gauge artifacts, etc.) with detection strategies is a curated knowledge base that improves over time. |
+| `protocols` | `route_protocol`, `get_protocol` | GPD provides canonical step-by-step methodology with checkpoints for each physics domain. FittingAgent follows these instead of inventing ad-hoc procedures. |
+| `conventions` | `subfield_defaults`, `convention_check` | GPD tracks 18 standard convention fields (metric signature, Fourier convention, natural units, gauge choice, etc.) across 14 subdomains. Prevents silent convention mismatches between agents. |
+| `patterns` | `lookup_pattern`, `add_pattern`, `seed_patterns` | GPD's `~/.gpd/` pattern store is the only persistent cross-session memory in the mtf pipeline. Errors found in one run surface in future runs on the same domain. |
+
+**`GPDMCPClient`** runs a dedicated background event loop in a daemon thread. Each server is a subprocess communicating over stdio MCP protocol. `make_tool(server, tool_name, description, params=)` returns an `sdk.Tool` (or `None` if unavailable), which phases filter into agent tool lists. `call(server, tool_name, **kwargs)` provides synchronous access for phase-level one-shot calls (e.g. convention locking, seeding patterns). `async_call()` offloads the blocking wait to a thread pool for use inside `asyncio.gather()` fan-outs.
+
+**How GPD tools flow to each agent**:
+- `LiteratureAgent` receives: `check_error_classes` (flag error-prone hypotheses), `route_protocol` (identify correct methodology)
+- `FittingAgent` receives: `route_protocol` + `get_protocol` (follow canonical procedure), `subfield_defaults` (correct conventions)
+- `ReviewerAgent` receives: all 8 tools above — `get_checklist`, `run_check` (5.1/5.2/5.3/5.18), `dimensional_check`, `limiting_case_check`, `check_error_classes`, `get_detection_strategy`, `lookup_pattern`, `add_pattern`
+
+**`MemoryKind` values for GPD data**:
+- `CONVENTIONS` — physics convention snapshot locked per domain at the start of the literature phase; included in all agent prompt contexts
 - `PHYSICS_VERDICT` — structured check results from the verification server; injected into debate synthesis context
 
-**Pipeline flow**: conventions are locked once in the literature phase via `subfield_defaults`. All three agent types accept `gpd_tools: list | None` for backward compatibility. `DebateEngine.synthesize()` conditionally adds a physics-first ranking criterion to the system prompt for fitting and review phases (not literature). Conventions and physics verdicts from memory are appended to the user content block sent to the synthesis call.
+**Pipeline flow**: conventions are locked once in the literature phase via `subfield_defaults` (called once per domain in `config.physics_domains`). All three agent types accept `gpd_tools: list | None` for backward compatibility. `DebateEngine.synthesize()` conditionally adds a physics-first ranking criterion to the system prompt for fitting and review phases (not literature). Conventions and physics verdicts from memory are appended to the user content block sent to the synthesis call.
+
+**When adding new physics capabilities to mtf**: check whether GPD already provides it as an MCP tool before implementing from scratch. The `gpd-mcp-skills` server (`list_skills`, `route_skill`) can discover available GPD capabilities programmatically.
 
 ## Key Invariants
 

--- a/README.md
+++ b/README.md
@@ -10,30 +10,44 @@ A multi-agent AI system for experimental physicists. Describe an unexplained phe
 flowchart TD
     Input(["📋 User Input\nphenomenon description + images + toolkit data"])
 
+    subgraph GPD ["🔧 GPD MCP SERVERS (optional)"]
+        direction TB
+        GV["verification\nchecks 5.1–5.19"]
+        GE["errors\n104 error classes"]
+        GP["protocols\n47+ domain protocols"]
+        GC["conventions\n18 subfields"]
+        GPat["patterns\ncross-session memory"]
+    end
+
     subgraph LIT ["① LITERATURE PHASE"]
         direction TB
-        L["L1 · L2 · L3\nN parallel agents\narxiv + Semantic Scholar"]
+        LC["Lock conventions\nvia GPD subfield_defaults"]
+        L["L1 · L2 · L3\nN parallel agents\narxiv + Semantic Scholar\n+ GPD: check_error_classes, route_protocol"]
         LD["🔀 Debate\nsynthesis call"]
         LU{"User approval"}
-        L --> LD --> LU
+        LC --> L --> LD --> LU
         LU -->|"reject: add feedback"| L
     end
 
     subgraph FIT ["② FITTING PHASE  —  per approved hypothesis"]
         direction TB
         FT["toolkit check\n(request missing data from user)"]
-        F["F1 · F2 · F3\nM parallel agents\nlmfit + numpy/scipy"]
-        FD["🔀 Debate\nsynthesis call"]
+        F["F1 · F2 · F3\nM parallel agents\nlmfit + numpy/scipy\n+ GPD: route_protocol, get_protocol, subfield_defaults"]
+        FD["🔀 Debate\nphysics-first ranking"]
         FU{"User approval"}
         FT --> F --> FD --> FU
     end
 
     subgraph REV ["③ REVIEW PHASE"]
         direction TB
-        R["R1 · R2 · R3\nK parallel agents\ntheory validity + next experiments"]
-        RD["🔀 Debate\nfinal synthesis"]
+        R["R1 · R2 · R3\nK parallel agents\n+ GPD: get_checklist, run_check, check_error_classes,\nlookup_pattern, add_pattern"]
+        RD["🔀 Debate\nphysics-first ranking"]
         R --> RD
     end
+
+    GPD -.->|"tools"| L
+    GPD -.->|"tools"| F
+    GPD -.->|"tools"| R
 
     Report(["📄 Final Report"])
 
@@ -60,9 +74,9 @@ Images are digested first (phase ⓪): `ImageDigestAgent` uses Claude's vision A
 | Agent | Phase | API | Tools | Memory written | Description |
 |-------|-------|-----|-------|----------------|-------------|
 | `ImageDigestAgent` | ⓪ Pre-processing | `messages.create()` (multimodal) | — | `IMAGE_DATA` | Encodes each user image as base64 and calls the vision API to extract plot type, axis labels/units/scale, numerical data series, quantitative features, and annotations. Runs in parallel, one instance per image. |
-| `LiteratureAgent` | ① Literature | `sdk.query()` | arxiv search, Semantic Scholar | `LITERATURE` | Searches arxiv and Semantic Scholar for papers relevant to the phenomenon. Returns a structured report: phenomenon summary, cited papers, ranked hypotheses, and key equations. Spawns N parallel instances (default 3). |
-| `FittingAgent` | ② Fitting | `sdk.query()` | `run_fitting_code()` (exec sandbox) | `FIT_RESULT` | Given an approved hypothesis and toolkit data, writes and executes `lmfit`/`numpy`/`scipy` fitting code. Reports χ², reduced χ², best-fit parameters with uncertainties, and hypothesis support. Rate-limited by `asyncio.Semaphore`. |
-| `ReviewerAgent` | ③ Review | `sdk.query()` | — | `REVIEW` | Evaluates hypothesis validity against data and literature, identifies weaknesses and confounds, and proposes specific follow-up experiments to distinguish competing explanations. Spawns K parallel instances (default 3). |
+| `LiteratureAgent` | ① Literature | `sdk.query()` | arxiv search, Semantic Scholar, GPD: `check_error_classes`, `route_protocol` | `LITERATURE` | Searches arxiv and Semantic Scholar. Calls GPD to identify error-prone hypotheses and the relevant computation protocol. Classifies each hypothesis by physical basis (first-principles / semi-empirical / purely empirical). Spawns N parallel instances (default 3). |
+| `FittingAgent` | ② Fitting | `sdk.query()` | GPD: `route_protocol`, `get_protocol`, `subfield_defaults` | `FIT_RESULT` | Given an approved hypothesis and toolkit data, retrieves the canonical domain protocol from GPD and writes fitting code that follows its checkpoints. Reports χ², parameters, and protocol compliance. Rate-limited by `asyncio.Semaphore`. |
+| `ReviewerAgent` | ③ Review | `sdk.query()` | GPD: `get_checklist`, `run_check`, `dimensional_check`, `limiting_case_check`, `check_error_classes`, `get_detection_strategy`, `lookup_pattern`, `add_pattern` | `REVIEW` | Runs GPD's structured verification checks (5.1 dimensional, 5.2 symmetry, 5.3 limiting cases, 5.18 fit-family) against each fit result. Produces SUPPORTED/PLAUSIBLE/SPECULATIVE/REJECTED verdicts citing check IDs. Records new error patterns for future sessions. Spawns K parallel instances (default 3). |
 | `ToolBuilderAgent` | ② Fitting (on demand) | `sdk.query()` | — | `TOOLKIT_DIGEST` | Invoked when a fitting agent requests toolkit data that the user has not pre-registered. Parses raw user input (functions, CSVs, code snippets) into `data_items` and `model_items` dicts via LLM-generated `exec()` code, then registers them in `ToolkitRegistry`. |
 
 All agents except `ImageDigestAgent` extend `BaseAgent`, which prepends a formatted `SharedMemory` context block before every `sdk.query()` call so every agent sees prior debate summaries, image digests, and user feedback.
@@ -78,13 +92,16 @@ All agents except `ImageDigestAgent` extend `BaseAgent`, which prepends a format
 git clone https://github.com/your-org/mtf.git
 cd mtf
 
-# Option A — pip
+# Option A — pip (without GPD physics verification)
 pip install -e ".[dev]"
+
+# Option A — pip (with GPD physics verification — recommended)
+pip install -e ".[dev,gpd]"
 
 # Option B — conda
 conda env create -f environment.yml
 conda activate mtf
-pip install -e .
+pip install -e ".[gpd]"
 
 # Set your API key
 export ANTHROPIC_API_KEY="sk-ant-..."
@@ -126,6 +143,9 @@ mtf
 | `--debate-model` | `claude-opus-4-6` | Model for debate synthesis |
 | `--images` | _(none)_ | Image files to digest (PNG, JPG, GIF, WebP; space-separated) |
 | `--image-digest-model` | `claude-opus-4-6` | Model for image digestion |
+| `--physics-domains` | `condensed_matter` | Physics domains for GPD (space-separated, e.g. `condensed_matter qft`) |
+| `--no-gpd` | _(off)_ | Disable GPD MCP physics verification servers |
+| `--gpd-servers` | _(all)_ | Which GPD servers to start (verification, errors, protocols, conventions, patterns) |
 
 ### 2. Python API — with your own data
 
@@ -219,18 +239,52 @@ If the fitting agent requests something that is not registered, the CLI will pau
 
 ---
 
+## GPD Physics Verification (optional)
+
+MTF integrates with [Get Physics Done (GPD)](https://github.com/psi-oss/get-physics-done) to shift hypothesis selection from chi-squared toward physical correctness. Rather than reimplementing physics verification from scratch, mtf **uses GPD's existing MCP servers as callable tools** — the same way it uses arxiv and Semantic Scholar.
+
+When GPD is installed, five MCP servers run as subprocesses alongside mtf:
+
+| GPD Server | What mtf gets from it | Which agents call it |
+|---|---|---|
+| **verification** | Structured physics checks: dimensional analysis (5.1), symmetry (5.2), limiting cases (5.3), fit-family mismatch (5.18) | ReviewerAgent |
+| **errors** | 104 curated physics error classes with detection strategies (sign errors, missing 2π factors, gauge artifacts, etc.) | LiteratureAgent, ReviewerAgent |
+| **protocols** | Step-by-step methodology with checkpoints for 47+ physics domains | LiteratureAgent, FittingAgent |
+| **conventions** | Canonical defaults for 18 subfields (Fourier convention, metric signature, natural units, gauge choice, etc.) | FittingAgent (via memory) |
+| **patterns** | Persistent cross-session error pattern library in `~/.gpd/` | ReviewerAgent |
+
+The key difference this makes: the `DebateEngine` synthesis for fitting and review phases ranks hypotheses by **physics check results first, chi-squared last**. A model with chi²=1.5 that passes all verification checks ranks above chi²=0.9 with a dimensional analysis failure.
+
+```bash
+# Without GPD (original behavior)
+mtf "anomalous resistivity plateau" --no-gpd
+
+# With GPD (recommended)
+pip install -e ".[gpd]"
+mtf "anomalous resistivity plateau"
+
+# Cross-domain phenomenon
+mtf "neutron star cooling anomaly" --physics-domains gr nuclear amo
+```
+
+GPD is fully optional — when not installed or disabled via `--no-gpd`, all agents run exactly as before.
+
+---
+
 ## Shared Memory
 
 All agents share a `SharedMemory` instance that accumulates entries across phases. Agents always see prior debate summaries and your feedback — no retrieval step needed.
 
 ```
-MemoryKind.IMAGE_DATA      → quantitative digests from user-provided images/plots
-MemoryKind.LITERATURE      → raw agent literature reports
-MemoryKind.DEBATE          → synthesized summaries from each phase
-MemoryKind.USER_FEEDBACK   → guidance you provide between rounds
-MemoryKind.HYPOTHESIS      → approved hypotheses passed to fitting
-MemoryKind.FIT_RESULT      → fitting agent outputs
-MemoryKind.REVIEW          → reviewer agent outputs
+MemoryKind.IMAGE_DATA       → quantitative digests from user-provided images/plots
+MemoryKind.LITERATURE       → raw agent literature reports
+MemoryKind.DEBATE           → synthesized summaries from each phase
+MemoryKind.USER_FEEDBACK    → guidance you provide between rounds
+MemoryKind.HYPOTHESIS       → approved hypotheses passed to fitting
+MemoryKind.FIT_RESULT       → fitting agent outputs
+MemoryKind.REVIEW           → reviewer agent outputs
+MemoryKind.CONVENTIONS      → GPD physics conventions locked per domain (sign, Fourier, units)
+MemoryKind.PHYSICS_VERDICT  → GPD structured verification results (check IDs + PASS/FAIL)
 ```
 
 ---
@@ -258,7 +312,8 @@ mtf/
 ├── tools/
 │   ├── arxiv_search.py
 │   ├── semantic_search.py
-│   └── fitting_tools.py      exec-based sandboxed fitting runner
+│   ├── fitting_tools.py      exec-based sandboxed fitting runner
+│   └── gpd_mcp.py            GPDMCPClient — bridges GPD MCP servers to sdk.Tool
 └── toolkit/
     └── registry.py     ToolkitRegistry (user data + model functions)
 ```

--- a/mtf/agents/fitting.py
+++ b/mtf/agents/fitting.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
 from mtf.toolkit.registry import ToolkitRegistry
 from mtf.tools.fitting_tools import run_fitting_code
-from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """You are an expert data analysis and model fitting agent for
 experimental physics. Given a hypothesis and experimental data, you:
@@ -22,11 +23,15 @@ experimental physics. Given a hypothesis and experimental data, you:
 4. Identify what data and model functions are needed from the toolkit.
 5. Write Python code using lmfit/numpy/scipy to fit the data, following the protocol
    retrieved above and incorporating the correct conventions.
-6. In the result dict, include protocol checkpoint verification under the key
-   'protocol_checkpoints' (a dict mapping checkpoint name to pass/fail/note).
+6. In the result dict, always include:
+   - 'protocol_followed': name of the protocol retrieved via get_protocol
+   - 'physical_parameter_ranges': dict mapping each parameter name to whether its
+     best-fit value falls within expected physical bounds (True/False + note)
+   - 'protocol_checkpoints_satisfied': list of protocol checkpoint names that passed
 7. Report fit quality (chi-squared, reduced chi-squared, residuals), best-fit
    parameters with uncertainties, and an assessment of whether the hypothesis is
-   supported.
+   supported. Chi-squared is a necessary metric but NOT the sole quality criterion;
+   physical correctness (parameter bounds, limiting cases, symmetry) matters more.
 
 Always write clean, well-commented fitting code."""
 
@@ -38,35 +43,13 @@ class FittingAgent(BaseAgent):
         model: str,
         memory: SharedMemory,
         toolkit: ToolkitRegistry,
-        gpd: GPDMCPClient | None = None,
+        gpd_tools: list[Any] | None = None,
     ) -> None:
-        gpd_tools = []
-        if gpd is not None and gpd.available:
-            gpd_tools = [
-                t
-                for t in [
-                    gpd.make_tool(
-                        "protocols",
-                        "route_protocol",
-                        "Find the canonical computation protocol for this type of physics calculation. Input: computation_type (str describing what you are computing, e.g. 'fit Drude model to optical conductivity'). Returns a ranked list of matching protocol names with relevance scores.",
-                    ),
-                    gpd.make_tool(
-                        "protocols",
-                        "get_protocol",
-                        "Retrieve the full step-by-step methodology for a named physics protocol, including mandatory checkpoints. Input: name (str, protocol name returned by route_protocol). Returns steps, checkpoints, and domain. Use this as a blueprint for your fitting code.",
-                    ),
-                    gpd.make_tool(
-                        "conventions",
-                        "subfield_defaults",
-                        "Get the canonical physics convention defaults for a given subfield (e.g. condensed_matter, qft, gr, plasma). Returns sign conventions, Fourier transform conventions, natural units, etc. Use these to ensure your fitting code uses correct conventions.",
-                    ),
-                ]
-                if t is not None
-            ]
+        extra_tools: list[Any] = gpd_tools if gpd_tools is not None else []
         super().__init__(
             agent_id=agent_id,
             model=model,
-            tools=[*gpd_tools],
+            tools=[*extra_tools],
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
         )
@@ -101,7 +84,10 @@ class FittingAgent(BaseAgent):
             "Assign your final result dict to a variable called 'result'. "
             "The result dict must include: 'parameters', 'uncertainties', "
             "'chi_squared', 'reduced_chi_squared', 'assessment', "
-            "'protocol_checkpoints'."
+            "'protocol_followed' (name of the protocol retrieved via get_protocol), "
+            "'physical_parameter_ranges' (dict mapping each parameter name to whether "
+            "its best-fit value falls within expected physical bounds), "
+            "'protocol_checkpoints_satisfied' (list of checkpoint names that passed)."
         )
         code = await self._query(
             task,

--- a/mtf/agents/fitting.py
+++ b/mtf/agents/fitting.py
@@ -6,13 +6,28 @@ from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
 from mtf.toolkit.registry import ToolkitRegistry
 from mtf.tools.fitting_tools import run_fitting_code
+from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """You are an expert data analysis and model fitting agent for
 experimental physics. Given a hypothesis and experimental data, you:
-1. Identify what data and model functions are needed from the toolkit
-2. Write Python code using lmfit/numpy/scipy to fit the data
-3. Report fit quality (chi-squared, reduced chi-squared, residuals), best-fit parameters
-   with uncertainties, and an assessment of whether the hypothesis is supported.
+
+1. At the start, call `route_protocol` with a description of the hypothesis and what
+   is being fit to find the canonical computation protocol.
+2. Call `get_protocol` with the protocol name returned by route_protocol to retrieve
+   the full step-by-step methodology and mandatory checkpoints — use this as a
+   blueprint for your fitting code.
+3. Call `subfield_defaults` with the relevant subfield (e.g. condensed_matter, qft,
+   gr, plasma) to retrieve canonical sign conventions, Fourier transform conventions,
+   natural units, etc. Ensure your fitting code uses these correct conventions.
+4. Identify what data and model functions are needed from the toolkit.
+5. Write Python code using lmfit/numpy/scipy to fit the data, following the protocol
+   retrieved above and incorporating the correct conventions.
+6. In the result dict, include protocol checkpoint verification under the key
+   'protocol_checkpoints' (a dict mapping checkpoint name to pass/fail/note).
+7. Report fit quality (chi-squared, reduced chi-squared, residuals), best-fit
+   parameters with uncertainties, and an assessment of whether the hypothesis is
+   supported.
+
 Always write clean, well-commented fitting code."""
 
 
@@ -23,11 +38,35 @@ class FittingAgent(BaseAgent):
         model: str,
         memory: SharedMemory,
         toolkit: ToolkitRegistry,
+        gpd: GPDMCPClient | None = None,
     ) -> None:
+        gpd_tools = []
+        if gpd is not None and gpd.available:
+            gpd_tools = [
+                t
+                for t in [
+                    gpd.make_tool(
+                        "protocols",
+                        "route_protocol",
+                        "Find the canonical computation protocol for this type of physics calculation. Input: computation_type (str describing what you are computing, e.g. 'fit Drude model to optical conductivity'). Returns a ranked list of matching protocol names with relevance scores.",
+                    ),
+                    gpd.make_tool(
+                        "protocols",
+                        "get_protocol",
+                        "Retrieve the full step-by-step methodology for a named physics protocol, including mandatory checkpoints. Input: name (str, protocol name returned by route_protocol). Returns steps, checkpoints, and domain. Use this as a blueprint for your fitting code.",
+                    ),
+                    gpd.make_tool(
+                        "conventions",
+                        "subfield_defaults",
+                        "Get the canonical physics convention defaults for a given subfield (e.g. condensed_matter, qft, gr, plasma). Returns sign conventions, Fourier transform conventions, natural units, etc. Use these to ensure your fitting code uses correct conventions.",
+                    ),
+                ]
+                if t is not None
+            ]
         super().__init__(
             agent_id=agent_id,
             model=model,
-            tools=[],
+            tools=[*gpd_tools],
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
         )
@@ -43,7 +82,12 @@ class FittingAgent(BaseAgent):
         )
         response = await self._query(
             task,
-            extra_kinds=(MemoryKind.LITERATURE, MemoryKind.DEBATE, MemoryKind.IMAGE_DATA),
+            extra_kinds=(
+                MemoryKind.LITERATURE,
+                MemoryKind.DEBATE,
+                MemoryKind.IMAGE_DATA,
+                MemoryKind.CONVENTIONS,
+            ),
         )
         lines = [l.strip() for l in response.splitlines() if l.strip()]
         return lines
@@ -56,11 +100,18 @@ class FittingAgent(BaseAgent):
             "Write Python fitting code using lmfit. "
             "Assign your final result dict to a variable called 'result'. "
             "The result dict must include: 'parameters', 'uncertainties', "
-            "'chi_squared', 'reduced_chi_squared', 'assessment'."
+            "'chi_squared', 'reduced_chi_squared', 'assessment', "
+            "'protocol_checkpoints'."
         )
         code = await self._query(
             task,
-            extra_kinds=(MemoryKind.LITERATURE, MemoryKind.DEBATE, MemoryKind.USER_FEEDBACK, MemoryKind.IMAGE_DATA),
+            extra_kinds=(
+                MemoryKind.LITERATURE,
+                MemoryKind.DEBATE,
+                MemoryKind.USER_FEEDBACK,
+                MemoryKind.IMAGE_DATA,
+                MemoryKind.CONVENTIONS,
+            ),
         )
         # Strip markdown code fences if present
         if "```" in code:

--- a/mtf/agents/literature.py
+++ b/mtf/agents/literature.py
@@ -22,14 +22,16 @@ the experimental phenomenon provided by the user.
 4. Produce a structured report with:
    a. Summary of the phenomenon
    b. Most relevant papers (with citations)
-   c. Proposed hypotheses ranked by plausibility, each explicitly classified as one of:
-      - first-principles (derived from theory)
-      - semi-empirical (phenomenological with physical motivation)
-      - purely empirical (fitting function)
+   c. Proposed hypotheses ranked by plausibility. For each hypothesis, explicitly
+      classify all three of:
+      - Basis: first-principles / semi-empirical / purely empirical
+      - Verification status: experimentally confirmed / theoretical prediction / disputed
+      - Known failure modes: from check_error_classes results
    d. Key equations or models from the literature
    e. Error-prone aspects flagged per hypothesis based on check_error_classes results
 
-Be precise, cite paper titles and authors."""
+Prefer first-principles hypotheses over phenomenological curve fits. Be precise, cite
+paper titles and authors."""
 
 
 class LiteratureAgent(BaseAgent):

--- a/mtf/agents/literature.py
+++ b/mtf/agents/literature.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
 from mtf.tools.arxiv_search import make_arxiv_search_tool
 from mtf.tools.semantic_search import make_semantic_search_tool
-from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """You are an expert theoretical and experimental physicist acting as a
 literature research agent. Your goal is to find relevant prior work that could explain
@@ -37,30 +38,13 @@ class LiteratureAgent(BaseAgent):
         agent_id: str,
         model: str,
         memory: SharedMemory,
-        gpd: GPDMCPClient | None = None,
+        gpd_tools: list[Any] | None = None,
     ) -> None:
-        gpd_tools = []
-        if gpd is not None and gpd.available:
-            gpd_tools = [
-                t
-                for t in [
-                    gpd.make_tool(
-                        "protocols",
-                        "route_protocol",
-                        "Find the canonical computation protocol relevant to this phenomenon before searching literature. Input: computation_type (str). Returns matching protocols — use to understand what methodology the relevant papers should follow.",
-                    ),
-                    gpd.make_tool(
-                        "errors",
-                        "check_error_classes",
-                        "Given a proposed hypothesis, identify the most likely physics error classes to watch for. Input: computation_desc (str describing the hypothesis or phenomenon). Returns top-15 relevant error classes — flag these when evaluating candidate hypotheses from literature.",
-                    ),
-                ]
-                if t is not None
-            ]
+        extra_tools: list[Any] = gpd_tools if gpd_tools is not None else []
         super().__init__(
             agent_id=agent_id,
             model=model,
-            tools=[make_arxiv_search_tool(), make_semantic_search_tool(), *gpd_tools],
+            tools=[make_arxiv_search_tool(), make_semantic_search_tool(), *extra_tools],
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
         )

--- a/mtf/agents/literature.py
+++ b/mtf/agents/literature.py
@@ -6,24 +6,61 @@ from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
 from mtf.tools.arxiv_search import make_arxiv_search_tool
 from mtf.tools.semantic_search import make_semantic_search_tool
+from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """You are an expert theoretical and experimental physicist acting as a
 literature research agent. Your goal is to find relevant prior work that could explain
-the experimental phenomenon provided by the user. Search arxiv and Semantic Scholar
-thoroughly. Prioritize recent, highly-cited work. Produce a structured report with:
-1. Summary of the phenomenon
-2. Most relevant papers (with citations)
-3. Proposed hypotheses ranked by plausibility
-4. Key equations or models from the literature
+the experimental phenomenon provided by the user.
+
+1. At the start, call `route_protocol` with a description of the phenomenon to
+   understand what computation methodology the relevant papers should follow.
+2. Search arxiv and Semantic Scholar thoroughly, prioritising recent, highly-cited work.
+3. For each proposed hypothesis, call `check_error_classes` with a description of the
+   hypothesis to identify the top-15 most likely physics error classes — flag
+   error-prone approaches in your report.
+4. Produce a structured report with:
+   a. Summary of the phenomenon
+   b. Most relevant papers (with citations)
+   c. Proposed hypotheses ranked by plausibility, each explicitly classified as one of:
+      - first-principles (derived from theory)
+      - semi-empirical (phenomenological with physical motivation)
+      - purely empirical (fitting function)
+   d. Key equations or models from the literature
+   e. Error-prone aspects flagged per hypothesis based on check_error_classes results
+
 Be precise, cite paper titles and authors."""
 
 
 class LiteratureAgent(BaseAgent):
-    def __init__(self, agent_id: str, model: str, memory: SharedMemory) -> None:
+    def __init__(
+        self,
+        agent_id: str,
+        model: str,
+        memory: SharedMemory,
+        gpd: GPDMCPClient | None = None,
+    ) -> None:
+        gpd_tools = []
+        if gpd is not None and gpd.available:
+            gpd_tools = [
+                t
+                for t in [
+                    gpd.make_tool(
+                        "protocols",
+                        "route_protocol",
+                        "Find the canonical computation protocol relevant to this phenomenon before searching literature. Input: computation_type (str). Returns matching protocols — use to understand what methodology the relevant papers should follow.",
+                    ),
+                    gpd.make_tool(
+                        "errors",
+                        "check_error_classes",
+                        "Given a proposed hypothesis, identify the most likely physics error classes to watch for. Input: computation_desc (str describing the hypothesis or phenomenon). Returns top-15 relevant error classes — flag these when evaluating candidate hypotheses from literature.",
+                    ),
+                ]
+                if t is not None
+            ]
         super().__init__(
             agent_id=agent_id,
             model=model,
-            tools=[make_arxiv_search_tool(), make_semantic_search_tool()],
+            tools=[make_arxiv_search_tool(), make_semantic_search_tool(), *gpd_tools],
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
         )
@@ -34,7 +71,14 @@ class LiteratureAgent(BaseAgent):
             f"relevant literature:\n\n{phenomenon}\n\n"
             "Produce a comprehensive literature report with hypotheses."
         )
-        report = await self._query(task, extra_kinds=(MemoryKind.USER_FEEDBACK, MemoryKind.IMAGE_DATA))
+        report = await self._query(
+            task,
+            extra_kinds=(
+                MemoryKind.USER_FEEDBACK,
+                MemoryKind.IMAGE_DATA,
+                MemoryKind.CONVENTIONS,
+            ),
+        )
         self._memory.add(
             MemoryKind.LITERATURE,
             report,

--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -13,8 +13,9 @@ fit results, and debate summaries, you:
 
 1. First call `check_error_classes` with the phenomenon description to identify the
    top-15 most relevant error classes to watch for.
-2. Call `get_checklist` with the physics domain (e.g. condensed_matter, qft, plasma,
-   amo) to retrieve the structured verification checklist.
+2. Call `get_checklist` for each physics domain listed in the conventions context
+   (e.g. condensed_matter, qft, plasma, amo). When the phenomenon spans multiple
+   domains, call it once per domain and merge the checklists.
 3. For each fit result, call `run_check` with the following mandatory check IDs,
    passing the fit result text as artifact_content:
    - "5.1" (dimensional consistency)

--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -4,24 +4,93 @@ from __future__ import annotations
 
 from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
+from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """You are a senior physics reviewer with broad expertise across
 condensed matter, high energy, AMO, and astrophysics. Given literature reports,
 fit results, and debate summaries, you:
-1. Assess the validity of each proposed hypothesis against the data and literature
-2. Identify weaknesses, alternative explanations, or confounds
-3. Suggest specific further experiments that would distinguish competing hypotheses
-4. Provide an overall recommendation
 
-Be rigorous, constructive, and cite specific evidence from the provided context."""
+1. First call `check_error_classes` with the phenomenon description to identify the
+   top-15 most relevant error classes to watch for.
+2. Call `get_checklist` with the physics domain (e.g. condensed_matter, qft, plasma,
+   amo) to retrieve the structured verification checklist.
+3. Work through each checklist item using `run_check` applied to the fit results and
+   hypotheses — cite specific check IDs in your verdict (e.g. "check 5.3 FAIL: model
+   does not recover free-particle dispersion at g→0").
+4. Call `lookup_pattern` to surface any known recurring errors in this domain and
+   category before finalising your verdict.
+5. Call `add_pattern` whenever you confirm a genuine physics error that would be useful
+   to record for future sessions.
+6. Assess the validity of each proposed hypothesis against the data and literature.
+7. Identify weaknesses, alternative explanations, or confounds.
+8. Suggest specific further experiments that would distinguish competing hypotheses.
+9. Provide an overall recommendation.
+
+Rank hypotheses by physics correctness first, chi² last. Produce structured verdicts
+that cite specific check IDs. Be rigorous, constructive, and cite specific evidence
+from the provided context."""
 
 
 class ReviewerAgent(BaseAgent):
-    def __init__(self, agent_id: str, model: str, memory: SharedMemory) -> None:
+    def __init__(
+        self,
+        agent_id: str,
+        model: str,
+        memory: SharedMemory,
+        gpd: GPDMCPClient | None = None,
+    ) -> None:
+        gpd_tools = []
+        if gpd is not None and gpd.available:
+            gpd_tools = [
+                t
+                for t in [
+                    gpd.make_tool(
+                        "verification",
+                        "get_checklist",
+                        "Get the domain-specific physics verification checklist. Input: domain (str, e.g. condensed_matter, qft, plasma, amo). Returns a list of check IDs and descriptions to work through systematically.",
+                    ),
+                    gpd.make_tool(
+                        "verification",
+                        "run_check",
+                        "Run a specific verification check against a hypothesis or fit result. check_id: '5.1'=Dimensional analysis, '5.2'=Symmetry, '5.3'=Limiting cases, '5.4'=Conservation laws, '5.5'=Numerical convergence, '5.18'=Fit family mismatch, '5.19'=Estimator family mismatch. domain: physics domain string. artifact_content: the text of the fit result or hypothesis to check.",
+                    ),
+                    gpd.make_tool(
+                        "verification",
+                        "dimensional_check",
+                        "Check dimensional consistency of physics equations. Input: expressions (list of strings, each a dimensional equation like '[M][L]^2[T]^-2 = [M][L]^2[T]^-2'). Returns pass/fail per expression with issues.",
+                    ),
+                    gpd.make_tool(
+                        "verification",
+                        "limiting_case_check",
+                        "Verify that a model's limiting cases are correctly documented. Input: expression (str, the model equation), limits (dict mapping limit description to expected behavior, e.g. {'g -> 0': 'reduces to free particle'}).",
+                    ),
+                    gpd.make_tool(
+                        "errors",
+                        "check_error_classes",
+                        "Given a description of a physics computation or hypothesis, return the top-15 most relevant error classes from a catalog of 104 known physics errors (sign errors, dimensional errors, convention pitfalls, convergence issues, etc.) with relevance scores.",
+                    ),
+                    gpd.make_tool(
+                        "errors",
+                        "get_detection_strategy",
+                        "Get the specific detection strategy for a known physics error class by integer ID (1-104). Use after check_error_classes to get actionable detection methods.",
+                    ),
+                    gpd.make_tool(
+                        "patterns",
+                        "lookup_pattern",
+                        "Search the persistent cross-session physics error pattern library for known error patterns in this domain. Input: domain (str), category (str, e.g. sign-error, dimensional-error, approximation-failure), keywords (str). Returns patterns found in previous runs.",
+                    ),
+                    gpd.make_tool(
+                        "patterns",
+                        "add_pattern",
+                        "Record a newly discovered physics error pattern for future reference across sessions. Input: domain, title, category (sign-error/factor-error/convention-pitfall/convergence-issue/approximation-failure/numerical-instability/conceptual-error/dimensional-error), severity (critical/warning/info), description, detection, prevention, example, test_value.",
+                    ),
+                ]
+                if t is not None
+            ]
         super().__init__(
             agent_id=agent_id,
             model=model,
-            tools=[],
+            tools=[*gpd_tools],
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
         )
@@ -40,6 +109,8 @@ class ReviewerAgent(BaseAgent):
                 MemoryKind.FIT_RESULT,
                 MemoryKind.USER_FEEDBACK,
                 MemoryKind.IMAGE_DATA,
+                MemoryKind.CONVENTIONS,
+                MemoryKind.PHYSICS_VERDICT,
             ),
         )
         self._memory.add(

--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -15,9 +15,13 @@ fit results, and debate summaries, you:
    top-15 most relevant error classes to watch for.
 2. Call `get_checklist` with the physics domain (e.g. condensed_matter, qft, plasma,
    amo) to retrieve the structured verification checklist.
-3. Work through each checklist item using `run_check` applied to the fit results and
-   hypotheses — cite specific check IDs in your verdict (e.g. "check 5.3 FAIL: model
-   does not recover free-particle dispersion at g→0").
+3. For each fit result, call `run_check` with the following mandatory check IDs,
+   passing the fit result text as artifact_content:
+   - "5.1" (dimensional consistency)
+   - "5.3" (limiting cases: does the model recover known limits?)
+   - "5.2" (symmetry: does the model respect required symmetries?)
+   - "5.18" (fit family mismatch: is the chosen model family appropriate?)
+   Also call `dimensional_check` if specific equations appear in the fit results.
 4. Call `lookup_pattern` to surface any known recurring errors in this domain and
    category before finalising your verdict.
 5. Call `add_pattern` whenever you confirm a genuine physics error that would be useful
@@ -27,9 +31,13 @@ fit results, and debate summaries, you:
 8. Suggest specific further experiments that would distinguish competing hypotheses.
 9. Provide an overall recommendation.
 
-Rank hypotheses by physics correctness first, chi² last. Produce structured verdicts
-that cite specific check IDs. Be rigorous, constructive, and cite specific evidence
-from the provided context."""
+For each hypothesis, produce a structured verdict using exactly one of:
+  SUPPORTED / PLAUSIBLE / SPECULATIVE / REJECTED
+with the relevant check IDs cited (e.g. "REJECTED — check 5.1 FAIL: units inconsistent").
+
+Rank hypotheses by: (1) physics check results, (2) parsimony, (3) first-principles
+basis, (4) chi² last. Be rigorous, constructive, and cite specific evidence from the
+provided context."""
 
 
 class ReviewerAgent(BaseAgent):

--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
-from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """You are a senior physics reviewer with broad expertise across
 condensed matter, high energy, AMO, and astrophysics. Given literature reports,
@@ -37,60 +38,13 @@ class ReviewerAgent(BaseAgent):
         agent_id: str,
         model: str,
         memory: SharedMemory,
-        gpd: GPDMCPClient | None = None,
+        gpd_tools: list[Any] | None = None,
     ) -> None:
-        gpd_tools = []
-        if gpd is not None and gpd.available:
-            gpd_tools = [
-                t
-                for t in [
-                    gpd.make_tool(
-                        "verification",
-                        "get_checklist",
-                        "Get the domain-specific physics verification checklist. Input: domain (str, e.g. condensed_matter, qft, plasma, amo). Returns a list of check IDs and descriptions to work through systematically.",
-                    ),
-                    gpd.make_tool(
-                        "verification",
-                        "run_check",
-                        "Run a specific verification check against a hypothesis or fit result. check_id: '5.1'=Dimensional analysis, '5.2'=Symmetry, '5.3'=Limiting cases, '5.4'=Conservation laws, '5.5'=Numerical convergence, '5.18'=Fit family mismatch, '5.19'=Estimator family mismatch. domain: physics domain string. artifact_content: the text of the fit result or hypothesis to check.",
-                    ),
-                    gpd.make_tool(
-                        "verification",
-                        "dimensional_check",
-                        "Check dimensional consistency of physics equations. Input: expressions (list of strings, each a dimensional equation like '[M][L]^2[T]^-2 = [M][L]^2[T]^-2'). Returns pass/fail per expression with issues.",
-                    ),
-                    gpd.make_tool(
-                        "verification",
-                        "limiting_case_check",
-                        "Verify that a model's limiting cases are correctly documented. Input: expression (str, the model equation), limits (dict mapping limit description to expected behavior, e.g. {'g -> 0': 'reduces to free particle'}).",
-                    ),
-                    gpd.make_tool(
-                        "errors",
-                        "check_error_classes",
-                        "Given a description of a physics computation or hypothesis, return the top-15 most relevant error classes from a catalog of 104 known physics errors (sign errors, dimensional errors, convention pitfalls, convergence issues, etc.) with relevance scores.",
-                    ),
-                    gpd.make_tool(
-                        "errors",
-                        "get_detection_strategy",
-                        "Get the specific detection strategy for a known physics error class by integer ID (1-104). Use after check_error_classes to get actionable detection methods.",
-                    ),
-                    gpd.make_tool(
-                        "patterns",
-                        "lookup_pattern",
-                        "Search the persistent cross-session physics error pattern library for known error patterns in this domain. Input: domain (str), category (str, e.g. sign-error, dimensional-error, approximation-failure), keywords (str). Returns patterns found in previous runs.",
-                    ),
-                    gpd.make_tool(
-                        "patterns",
-                        "add_pattern",
-                        "Record a newly discovered physics error pattern for future reference across sessions. Input: domain, title, category (sign-error/factor-error/convention-pitfall/convergence-issue/approximation-failure/numerical-instability/conceptual-error/dimensional-error), severity (critical/warning/info), description, detection, prevention, example, test_value.",
-                    ),
-                ]
-                if t is not None
-            ]
+        extra_tools: list[Any] = gpd_tools if gpd_tools is not None else []
         super().__init__(
             agent_id=agent_id,
             model=model,
-            tools=[*gpd_tools],
+            tools=[*extra_tools],
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
         )

--- a/mtf/cli.py
+++ b/mtf/cli.py
@@ -36,6 +36,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Input files to digest before analysis (images: PNG, JPG, GIF, WebP; documents: PDF)",
     )
     p.add_argument("--image-digest-model", default="claude-opus-4-6")
+
+    # GPD MCP integration
+    p.add_argument(
+        "--physics-domains",
+        nargs="+",
+        default=["condensed_matter"],
+        metavar="DOMAIN",
+        help="Physics domains for GPD conventions and checklists, e.g. "
+        "'condensed_matter qft' for cross-domain phenomena (default: condensed_matter)",
+    )
+    p.add_argument(
+        "--no-gpd",
+        action="store_true",
+        help="Disable GPD MCP physics verification servers",
+    )
+    p.add_argument(
+        "--gpd-servers",
+        nargs="+",
+        metavar="SERVER",
+        default=None,
+        help="GPD MCP servers to start (default: all). "
+        "Choices: verification, errors, protocols, conventions, patterns",
+    )
     return p
 
 
@@ -51,6 +74,13 @@ def main() -> None:
         print("No phenomenon provided. Exiting.")
         sys.exit(1)
 
+    gpd_kwargs: dict[str, object] = {
+        "enable_gpd_mcp": not args.no_gpd,
+        "physics_domains": args.physics_domains,
+    }
+    if args.gpd_servers is not None:
+        gpd_kwargs["gpd_servers"] = args.gpd_servers
+
     config = MTFConfig(
         n_literature=args.n_literature,
         n_fitting=args.n_fitting,
@@ -61,6 +91,7 @@ def main() -> None:
         debate_model=args.debate_model,
         max_debate_rounds=args.max_debate_rounds,
         image_digest_model=args.image_digest_model,
+        **gpd_kwargs,  # type: ignore[arg-type]
     )
     orchestrator = MTFOrchestrator(config=config)
     asyncio.run(orchestrator.run(phenomenon, files=args.files or None))

--- a/mtf/cli.py
+++ b/mtf/cli.py
@@ -36,6 +36,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Input files to digest before analysis (images: PNG, JPG, GIF, WebP; documents: PDF)",
     )
     p.add_argument("--image-digest-model", default="claude-opus-4-6")
+
+    # GPD MCP integration
+    p.add_argument(
+        "--physics-domain",
+        default="condensed_matter",
+        metavar="DOMAIN",
+        help="Physics domain for GPD conventions (default: condensed_matter)",
+    )
+    p.add_argument(
+        "--no-gpd",
+        action="store_true",
+        help="Disable GPD MCP physics verification servers",
+    )
+    p.add_argument(
+        "--gpd-servers",
+        nargs="+",
+        metavar="SERVER",
+        default=None,
+        help="GPD MCP servers to start (default: all). "
+        "Choices: verification, errors, protocols, conventions, patterns",
+    )
     return p
 
 
@@ -51,6 +72,13 @@ def main() -> None:
         print("No phenomenon provided. Exiting.")
         sys.exit(1)
 
+    gpd_kwargs: dict[str, object] = {
+        "enable_gpd_mcp": not args.no_gpd,
+        "physics_domain": args.physics_domain,
+    }
+    if args.gpd_servers is not None:
+        gpd_kwargs["gpd_servers"] = args.gpd_servers
+
     config = MTFConfig(
         n_literature=args.n_literature,
         n_fitting=args.n_fitting,
@@ -61,6 +89,7 @@ def main() -> None:
         debate_model=args.debate_model,
         max_debate_rounds=args.max_debate_rounds,
         image_digest_model=args.image_digest_model,
+        **gpd_kwargs,  # type: ignore[arg-type]
     )
     orchestrator = MTFOrchestrator(config=config)
     asyncio.run(orchestrator.run(phenomenon, files=args.files or None))

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -28,3 +28,10 @@ class MTFConfig:
 
     # Toolkit
     toolkit_items: dict[str, object] = field(default_factory=dict)
+
+    # GPD MCP integration
+    enable_gpd_mcp: bool = True
+    physics_domain: str = "condensed_matter"  # passed to get_checklist / subfield_defaults
+    gpd_servers: list[str] = field(
+        default_factory=lambda: ["verification", "errors", "protocols", "conventions", "patterns"]
+    )

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -31,7 +31,9 @@ class MTFConfig:
 
     # GPD MCP integration
     enable_gpd_mcp: bool = True
-    physics_domain: str = "condensed_matter"  # passed to get_checklist / subfield_defaults
+    physics_domains: list[str] = field(
+        default_factory=lambda: ["condensed_matter"],
+    )  # one or more domains; passed to get_checklist / subfield_defaults
     gpd_servers: list[str] = field(
         default_factory=lambda: ["verification", "errors", "protocols", "conventions", "patterns"]
     )

--- a/mtf/debate.py
+++ b/mtf/debate.py
@@ -32,17 +32,47 @@ class DebateEngine:
             f"--- Report {i + 1} ---\n{r}" for i, r in enumerate(reports)
         )
         memory_ctx = self._memory.format_context()
-        system = (
+
+        base_system = (
             f"You are a synthesis engine for the {phase} phase of a multi-agent "
             "physics research assistant. Your job is to produce a single coherent "
             "synthesis of the provided agent reports, resolving contradictions and "
             "highlighting the strongest hypotheses or conclusions. Be concise and precise."
         )
+
+        if phase in ("fitting", "review"):
+            physics_criterion = (
+                "\n\nIMPORTANT — ranking criterion for hypotheses: physical correctness "
+                "takes priority over fit quality. Apply this order:\n"
+                "1. Physics checks: hypotheses that pass dimensional analysis (5.1), "
+                "limiting cases (5.3), symmetry (5.2), and fit-family validity (5.18) "
+                "rank above those that fail, regardless of chi².\n"
+                "2. Parsimony: prefer fewer free parameters at comparable fit quality.\n"
+                "3. First-principles basis: a derivation from known theory outranks a "
+                "phenomenological ansatz at equal fit quality.\n"
+                "4. Fit quality (chi², reduced chi²): used as tiebreaker only.\n"
+                "Cite specific check IDs (e.g. 'check 5.3 FAIL') from the agent reports "
+                "when justifying your ranking. A model with chi²=1.5 and all checks PASS "
+                "should rank above chi²=0.9 with check 5.1 FAIL."
+            )
+            system = base_system + physics_criterion
+        else:
+            system = base_system
+
         user_parts = []
         if memory_ctx:
             user_parts.append(memory_ctx)
         if extra_context:
             user_parts.append(extra_context)
+
+        # Inject conventions and physics verdicts if present
+        conv_entries = self._memory.filter(MemoryKind.CONVENTIONS)
+        verdict_entries = self._memory.filter(MemoryKind.PHYSICS_VERDICT)
+        if conv_entries:
+            user_parts.append("Physics conventions in use:\n" + "\n".join(e.content for e in conv_entries))
+        if verdict_entries:
+            user_parts.append("Physics verification verdicts:\n" + "\n".join(e.content for e in verdict_entries))
+
         user_parts.append(f"Agent reports to synthesize:\n\n{numbered}")
         user_content = "\n\n".join(user_parts)
 

--- a/mtf/memory.py
+++ b/mtf/memory.py
@@ -16,6 +16,9 @@ class MemoryKind(str, Enum):
     REVIEW = "review"
     IMAGE_DATA = "image_data"
     TOOLKIT_DIGEST = "toolkit_digest"
+    # GPD MCP integration
+    CONVENTIONS = "conventions"        # physics convention lock from gpd-conventions
+    PHYSICS_VERDICT = "physics_verdict"  # structured check results from gpd-verification
 
 
 @dataclass

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -13,6 +13,7 @@ from mtf.phases.fitting_phase import run_fitting_phase
 from mtf.phases.literature_phase import run_literature_phase
 from mtf.phases.review_phase import run_review_phase
 from mtf.toolkit.registry import ToolkitRegistry
+from mtf.tools.gpd_mcp import GPDMCPClient
 
 
 class MTFOrchestrator:
@@ -43,63 +44,80 @@ class MTFOrchestrator:
         Returns:
             Final report as a string.
         """
+        gpd = GPDMCPClient() if self._config.enable_gpd_mcp else None
+        if gpd is not None:
+            gpd.start(self._config.gpd_servers)
+
         await self._interface.show(
-            f"**MTF starting**\n\nPhenomenon:\n{phenomenon}",
+            f"**MTF starting**\n\nPhenomenon:\n{phenomenon}"
+            + ("\n\n*GPD MCP physics verification: active*" if gpd and gpd.available else ""),
             title="My Theorist Friend",
         )
 
-        # If no files were passed programmatically, ask the user interactively
-        if files is None:
-            files = await self._interface.ask_for_files() or None
+        try:
+            # Seed GPD patterns at startup (idempotent)
+            if gpd is not None and gpd.available:
+                gpd.call("patterns", "seed_patterns")
 
-        # File digestion (runs before any analysis phase so all agents see the data)
-        if files:
-            await self._interface.show(
-                f"**File digestion**\n\nProcessing {len(files)} file(s) via parallel subagents...",
-                title="MTF: File Digest",
-            )
-            digester = ImageDigestAgent(self._config, self._memory)
-            digests = await digester.digest_all(files)
-            summary_lines = [
-                f"- `{Path(p).name}`: {d[:120].splitlines()[0]}..."
-                for p, d in zip(files, digests)
-            ]
-            if len(files) > 1:
-                summary_lines.append(
-                    "\n*Cross-file synthesis stored in shared memory.*"
+            # If no files were passed programmatically, ask the user interactively
+            if files is None:
+                files = await self._interface.ask_for_files() or None
+
+            # File digestion (runs before any analysis phase so all agents see the data)
+            if files:
+                await self._interface.show(
+                    f"**File digestion**\n\nProcessing {len(files)} file(s) via parallel subagents...",
+                    title="MTF: File Digest",
                 )
-            await self._interface.show(
-                "**File digests stored in shared memory.**\n\n"
-                + "\n".join(summary_lines),
-                title="MTF: File Digest",
+                digester = ImageDigestAgent(self._config, self._memory)
+                digests = await digester.digest_all(files)
+                summary_lines = [
+                    f"- `{Path(p).name}`: {d[:120].splitlines()[0]}..."
+                    for p, d in zip(files, digests)
+                ]
+                if len(files) > 1:
+                    summary_lines.append(
+                        "\n*Cross-file synthesis stored in shared memory.*"
+                    )
+                await self._interface.show(
+                    "**File digests stored in shared memory.**\n\n"
+                    + "\n".join(summary_lines),
+                    title="MTF: File Digest",
+                )
+
+            # Phase 1: Literature
+            hypotheses = await run_literature_phase(
+                phenomenon=phenomenon,
+                config=self._config,
+                memory=self._memory,
+                interface=self._interface,
+                debate_engine=self._debate,
+                gpd=gpd,
             )
 
-        # Phase 1: Literature
-        hypotheses = await run_literature_phase(
-            phenomenon=phenomenon,
-            config=self._config,
-            memory=self._memory,
-            interface=self._interface,
-            debate_engine=self._debate,
-        )
+            # Phase 2: Fitting
+            await run_fitting_phase(
+                hypotheses=hypotheses,
+                config=self._config,
+                memory=self._memory,
+                interface=self._interface,
+                debate_engine=self._debate,
+                toolkit=self._toolkit,
+                gpd=gpd,
+            )
 
-        # Phase 2: Fitting
-        await run_fitting_phase(
-            hypotheses=hypotheses,
-            config=self._config,
-            memory=self._memory,
-            interface=self._interface,
-            debate_engine=self._debate,
-            toolkit=self._toolkit,
-        )
+            # Phase 3: Review
+            final_report = await run_review_phase(
+                phenomenon=phenomenon,
+                config=self._config,
+                memory=self._memory,
+                interface=self._interface,
+                debate_engine=self._debate,
+                gpd=gpd,
+            )
 
-        # Phase 3: Review
-        final_report = await run_review_phase(
-            phenomenon=phenomenon,
-            config=self._config,
-            memory=self._memory,
-            interface=self._interface,
-            debate_engine=self._debate,
-        )
+        finally:
+            if gpd is not None:
+                gpd.close()
 
         return final_report

--- a/mtf/phases/fitting_phase.py
+++ b/mtf/phases/fitting_phase.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from mtf.agents.fitting import FittingAgent
 from mtf.agents.tool_builder import ToolBuilderAgent
@@ -26,9 +27,28 @@ async def run_fitting_phase(
     interface: HumanInterface,
     debate_engine: DebateEngine,
     toolkit: ToolkitRegistry,
+    gpd: Any | None = None,
 ) -> str:
     """For each hypothesis, fan out M fitting agents and synthesize results."""
     semaphore = asyncio.Semaphore(config.fitting_semaphore_limit)
+
+    # Build GPD tools for FittingAgent
+    gpd_tools: list[Any] = []
+    if gpd is not None:
+        gpd_tools = [t for t in [
+            gpd.make_tool("protocols", "route_protocol",
+                "Find the canonical computation protocol for this type of physics fitting. "
+                "Input: computation_type (str describing what you're fitting). "
+                "Returns matching protocols. Call this before writing any fitting code."),
+            gpd.make_tool("protocols", "get_protocol",
+                "Retrieve the full step-by-step methodology for a named physics protocol, "
+                "including checkpoints you must satisfy. Input: name (str from route_protocol). "
+                "Follow these steps in your fitting code."),
+            gpd.make_tool("conventions", "subfield_defaults",
+                "Get canonical physics convention defaults for a subfield "
+                "(e.g. condensed_matter, qft, gr, amo). Use to ensure your fitting code "
+                "uses correct sign conventions, Fourier transforms, and natural units."),
+        ] if t is not None]
 
     async def fit_with_semaphore(agent: FittingAgent, hypothesis: str) -> dict[str, object]:
         async with semaphore:
@@ -46,6 +66,7 @@ async def run_fitting_phase(
         model=config.fitting_model,
         memory=memory,
         toolkit=toolkit,
+        gpd_tools=gpd_tools,
     )
     seen_missing: set[str] = set()
     for hypothesis in hypotheses:
@@ -114,6 +135,7 @@ async def run_fitting_phase(
                     model=config.fitting_model,
                     memory=memory,
                     toolkit=toolkit,
+                    gpd_tools=gpd_tools,
                 )
                 for i in range(config.n_fitting)
             ]
@@ -129,6 +151,7 @@ async def run_fitting_phase(
                 model=config.fitting_model,
                 memory=memory,
                 toolkit=toolkit,
+                gpd_tools=gpd_tools,
             )
             for i in range(config.n_fitting)
         ]

--- a/mtf/phases/literature_phase.py
+++ b/mtf/phases/literature_phase.py
@@ -38,13 +38,17 @@ async def run_literature_phase(
                 "Use to identify what methodology the literature should follow."),
         ] if t is not None]
 
-    # Lock physics conventions before the first fan-out
+    # Lock physics conventions before the first fan-out (one entry per domain)
     if gpd is not None:
-        conventions = gpd.call("conventions", "subfield_defaults", domain=config.physics_domain)
-        if conventions:
-            memory.add(MemoryKind.CONVENTIONS, conventions)
+        for domain in config.physics_domains:
+            conventions = gpd.call("conventions", "subfield_defaults", domain=domain)
+            if conventions:
+                memory.add(MemoryKind.CONVENTIONS, conventions, domain=domain)
+        locked = config.physics_domains
+        if locked:
+            domains_str = ", ".join(f"**{d}**" for d in locked)
             await interface.show(
-                f"Physics conventions locked for domain **{config.physics_domain}**.",
+                f"Physics conventions locked for: {domains_str}.",
                 title="MTF: GPD Conventions",
             )
 

--- a/mtf/phases/literature_phase.py
+++ b/mtf/phases/literature_phase.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from mtf.agents.literature import LiteratureAgent
 from mtf.config import MTFConfig
@@ -17,11 +18,36 @@ async def run_literature_phase(
     memory: SharedMemory,
     interface: HumanInterface,
     debate_engine: DebateEngine,
+    gpd: Any | None = None,
 ) -> list[str]:
     """Fan out N literature agents, debate, get user approval, loop.
 
     Returns approved hypotheses as a list of strings.
     """
+    # Build GPD tools for LiteratureAgent
+    gpd_tools: list[Any] = []
+    if gpd is not None:
+        gpd_tools = [t for t in [
+            gpd.make_tool("errors", "check_error_classes",
+                "Given a physics phenomenon or hypothesis description, return the top relevant "
+                "physics error classes from a catalog of 104 known errors, with relevance scores "
+                "and detection strategies. Call this first before searching literature."),
+            gpd.make_tool("protocols", "route_protocol",
+                "Find the canonical computation protocol for a given physics calculation type. "
+                "Input: computation_type (str). Returns matching protocols with relevance scores. "
+                "Use to identify what methodology the literature should follow."),
+        ] if t is not None]
+
+    # Lock physics conventions before the first fan-out
+    if gpd is not None:
+        conventions = gpd.call("conventions", "subfield_defaults", domain=config.physics_domain)
+        if conventions:
+            memory.add(MemoryKind.CONVENTIONS, conventions)
+            await interface.show(
+                f"Physics conventions locked for domain **{config.physics_domain}**.",
+                title="MTF: GPD Conventions",
+            )
+
     synthesis = ""
     for round_num in range(1, config.max_debate_rounds + 1):
         await interface.show(
@@ -35,6 +61,7 @@ async def run_literature_phase(
                 agent_id=f"lit-{i}",
                 model=config.literature_model,
                 memory=memory,
+                gpd_tools=gpd_tools,
             )
             for i in range(config.n_literature)
         ]

--- a/mtf/phases/review_phase.py
+++ b/mtf/phases/review_phase.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from mtf.agents.reviewer import ReviewerAgent
 from mtf.config import MTFConfig
@@ -17,8 +18,48 @@ async def run_review_phase(
     memory: SharedMemory,
     interface: HumanInterface,
     debate_engine: DebateEngine,
+    gpd: Any | None = None,
 ) -> str:
     """Fan out K reviewer agents and synthesize a final report."""
+    # Build GPD tools for ReviewerAgent
+    gpd_tools: list[Any] = []
+    if gpd is not None:
+        gpd_tools = [t for t in [
+            gpd.make_tool("verification", "get_checklist",
+                "Get the domain-specific physics verification checklist. "
+                "Input: domain (str, e.g. condensed_matter, qft, gr, amo). "
+                "Returns list of check IDs and descriptions. Call this FIRST."),
+            gpd.make_tool("verification", "run_check",
+                "Run a specific physics verification check against a fit result or hypothesis text. "
+                "Input: check_id (str: '5.1'=dimensional, '5.2'=symmetry, '5.3'=limiting_cases, "
+                "'5.4'=conservation, '5.5'=convergence, '5.18'=fit_family_mismatch), "
+                "domain (str), artifact_content (str of the fit result). "
+                "Returns automated issues found."),
+            gpd.make_tool("verification", "dimensional_check",
+                "Check dimensional consistency of physics equations. "
+                "Input: expressions (list of strings like '[M][L]^2[T]^-2 = [M][L]^2[T]^-2'). "
+                "Returns pass/fail per expression."),
+            gpd.make_tool("verification", "limiting_case_check",
+                "Verify that a model's limiting cases are documented and correct. "
+                "Input: expression (str), limits (dict mapping limit description to expected result)."),
+            gpd.make_tool("errors", "check_error_classes",
+                "Given a physics computation description, return the top-15 relevant error classes "
+                "from a catalog of 104 known physics errors. Call this early in your review "
+                "to know what specific mistakes to hunt for."),
+            gpd.make_tool("errors", "get_detection_strategy",
+                "Get the detection strategy for a specific physics error class by ID (int 1-104). "
+                "Use after check_error_classes identifies relevant error classes."),
+            gpd.make_tool("patterns", "lookup_pattern",
+                "Search the persistent cross-session physics error pattern library. "
+                "Input: domain (str), category (str: sign-error/factor-error/convention-pitfall/"
+                "convergence-issue/approximation-failure/dimensional-error), keywords (str). "
+                "Returns known patterns from previous runs."),
+            gpd.make_tool("patterns", "add_pattern",
+                "Record a newly discovered physics error pattern for future reference across sessions. "
+                "Input: domain, title, category, severity (low/medium/high/critical), "
+                "description, detection, prevention, example, test_value."),
+        ] if t is not None]
+
     await interface.show(
         f"**Review phase**\n\nDispatching {config.n_reviewer} reviewer agents...",
         title="MTF: Review",
@@ -29,6 +70,7 @@ async def run_review_phase(
             agent_id=f"rev-{i}",
             model=config.reviewer_model,
             memory=memory,
+            gpd_tools=gpd_tools,
         )
         for i in range(config.n_reviewer)
     ]

--- a/mtf/phases/review_phase.py
+++ b/mtf/phases/review_phase.py
@@ -28,7 +28,9 @@ async def run_review_phase(
             gpd.make_tool("verification", "get_checklist",
                 "Get the domain-specific physics verification checklist. "
                 "Input: domain (str, e.g. condensed_matter, qft, gr, amo). "
-                "Returns list of check IDs and descriptions. Call this FIRST."),
+                "Returns list of check IDs and descriptions. Call this FIRST, "
+                "once per domain if the phenomenon spans multiple domains, "
+                "and merge the resulting checklists."),
             gpd.make_tool("verification", "run_check",
                 "Run a specific physics verification check against a fit result or hypothesis text. "
                 "Input: check_id (str: '5.1'=dimensional, '5.2'=symmetry, '5.3'=limiting_cases, "

--- a/mtf/tools/gpd_mcp.py
+++ b/mtf/tools/gpd_mcp.py
@@ -1,0 +1,164 @@
+"""GPD MCP client: bridges GPD MCP servers to sdk.Tool objects.
+
+Each GPD server runs as a subprocess communicating over stdio MCP protocol.
+A dedicated background event loop handles all async MCP I/O, exposing
+synchronous sdk.Tool-compatible callables to mtf agents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import threading
+from contextlib import AsyncExitStack
+from typing import Any
+
+import claude_agent_sdk as sdk
+
+logger = logging.getLogger(__name__)
+
+# Maps short server names to their Python module paths in the GPD package.
+_SERVER_MODULES: dict[str, str] = {
+    "verification": "gpd.mcp.servers.verification_server",
+    "errors": "gpd.mcp.servers.errors_mcp",
+    "protocols": "gpd.mcp.servers.protocols_server",
+    "conventions": "gpd.mcp.servers.conventions_server",
+    "patterns": "gpd.mcp.servers.patterns_server",
+}
+
+
+class GPDMCPClient:
+    """Manages live connections to one or more GPD MCP servers.
+
+    All async MCP I/O runs in a dedicated background thread with its own
+    event loop so that sync tool functions (required by sdk.Tool.from_function)
+    can block-call into the async MCP session without conflicting with the
+    main asyncio event loop used by the rest of mtf.
+
+    Usage::
+
+        client = GPDMCPClient()
+        client.start(["verification", "errors", "protocols", "conventions", "patterns"])
+        tool = client.make_tool("verification", "get_checklist",
+                                "Get domain-specific physics checklist.")
+        # ... pass tool to agents ...
+        client.close()
+    """
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._loop.run_forever, daemon=True, name="gpd-mcp-loop"
+        )
+        self._thread.start()
+        self._sessions: dict[str, Any] = {}  # server_name -> ClientSession
+        self._exit_stack: AsyncExitStack | None = None
+        self._available: bool = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self, server_names: list[str]) -> None:
+        """Start the requested GPD MCP servers.
+
+        Silently no-ops if the ``get-physics-done`` package is not installed.
+        """
+        try:
+            self._run(self._start_async(server_names))
+            self._available = bool(self._sessions)
+        except Exception as exc:
+            logger.warning("GPD MCP servers could not start (%s). Continuing without GPD.", exc)
+            self._available = False
+
+    async def _start_async(self, server_names: list[str]) -> None:
+        from mcp import ClientSession  # noqa: PLC0415
+        from mcp.client.stdio import StdioServerParameters, stdio_client  # noqa: PLC0415
+
+        self._exit_stack = AsyncExitStack()
+        await self._exit_stack.__aenter__()
+        for name in server_names:
+            module = _SERVER_MODULES.get(name)
+            if module is None:
+                logger.warning("Unknown GPD server '%s', skipping.", name)
+                continue
+            try:
+                params = StdioServerParameters(
+                    command=sys.executable, args=["-m", module]
+                )
+                read, write = await self._exit_stack.enter_async_context(
+                    stdio_client(params)
+                )
+                session = await self._exit_stack.enter_async_context(
+                    ClientSession(read, write)
+                )
+                await session.initialize()
+                self._sessions[name] = session
+                logger.debug("GPD MCP server '%s' started.", name)
+            except Exception as exc:
+                logger.warning("Failed to start GPD server '%s': %s", name, exc)
+
+    def close(self) -> None:
+        """Shut down all MCP server subprocesses and stop the background loop."""
+        try:
+            if self._exit_stack is not None:
+                self._run(self._exit_stack.__aexit__(None, None, None))
+        except Exception as exc:
+            logger.debug("Error during GPD MCP cleanup: %s", exc)
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+
+    # ------------------------------------------------------------------
+    # Calling tools
+    # ------------------------------------------------------------------
+
+    def call(self, server: str, tool_name: str, **kwargs: Any) -> str:
+        """Synchronously call an MCP tool and return its text result.
+
+        Returns an empty string if the server is unavailable.
+        """
+        session = self._sessions.get(server)
+        if session is None:
+            return ""
+        try:
+            result = self._run(session.call_tool(tool_name, kwargs))
+            if hasattr(result, "content") and result.content:
+                return result.content[0].text
+            return str(result)
+        except Exception as exc:
+            logger.warning("GPD tool call %s/%s failed: %s", server, tool_name, exc)
+            return ""
+
+    def make_tool(self, server: str, tool_name: str, description: str) -> sdk.Tool | None:
+        """Return an sdk.Tool backed by the given MCP server tool.
+
+        Returns ``None`` if the server was not started (e.g. GPD not installed),
+        so callers can filter None values out of their tool lists.
+        """
+        if server not in self._sessions:
+            return None
+
+        client = self  # captured by closure
+
+        def _tool_fn(**kwargs: Any) -> str:
+            return client.call(server, tool_name, **kwargs)
+
+        _tool_fn.__name__ = tool_name
+        _tool_fn.__doc__ = description
+        return sdk.Tool.from_function(_tool_fn)
+
+    @property
+    def available(self) -> bool:
+        """True if at least one GPD MCP server started successfully."""
+        return self._available
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run(self, coro: Any) -> Any:
+        """Submit a coroutine to the background event loop and block for result."""
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=60)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ mtf = "mtf.cli:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "mypy>=1.9", "ruff>=0.4"]
+gpd = ["get-physics-done>=1.1.0", "mcp>=1.26.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/test_gpd_integration.py
+++ b/tests/test_gpd_integration.py
@@ -1,0 +1,288 @@
+"""Tests for GPD MCP integration.
+
+All tests work WITHOUT the get-physics-done package installed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mtf.config import MTFConfig
+from mtf.debate import DebateEngine
+from mtf.memory import MemoryKind, SharedMemory
+from mtf.toolkit.registry import ToolkitRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockInterface:
+    """Minimal mock of HumanInterface for tests."""
+
+    async def show(self, content: str, title: str = "") -> None:
+        pass
+
+    async def ask(self, prompt: str) -> str:
+        return ""
+
+    async def confirm(self, prompt: str) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# GPDMCPClient tests
+# ---------------------------------------------------------------------------
+
+
+def test_gpd_client_not_started_returns_empty():
+    """call() on a client that was never started returns empty string."""
+    from mtf.tools.gpd_mcp import GPDMCPClient
+
+    client = GPDMCPClient()
+    # Never called client.start(), so no sessions exist
+    result = client.call("verification", "get_checklist")
+    assert result == ""
+    client._loop.call_soon_threadsafe(client._loop.stop)
+    client._thread.join(timeout=5)
+
+
+def test_gpd_client_make_tool_unavailable_returns_none():
+    """make_tool() returns None when server is not in sessions."""
+    from mtf.tools.gpd_mcp import GPDMCPClient
+
+    client = GPDMCPClient()
+    tool = client.make_tool("verification", "get_checklist", "Get checklist")
+    assert tool is None
+    client._loop.call_soon_threadsafe(client._loop.stop)
+    client._thread.join(timeout=5)
+
+
+def test_gpd_client_available_false_before_start():
+    """client.available is False before start() is called."""
+    from mtf.tools.gpd_mcp import GPDMCPClient
+
+    client = GPDMCPClient()
+    assert client.available is False
+    client._loop.call_soon_threadsafe(client._loop.stop)
+    client._thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Memory tests
+# ---------------------------------------------------------------------------
+
+
+def test_memory_kind_conventions():
+    """CONVENTIONS MemoryKind can be added and filtered."""
+    m = SharedMemory()
+    m.add(MemoryKind.CONVENTIONS, "metric signature (-,+,+,+)")
+    m.add(MemoryKind.LITERATURE, "some paper")
+    entries = m.filter(MemoryKind.CONVENTIONS)
+    assert len(entries) == 1
+    assert entries[0].content == "metric signature (-,+,+,+)"
+    assert entries[0].kind == MemoryKind.CONVENTIONS
+
+
+def test_memory_kind_physics_verdict():
+    """PHYSICS_VERDICT MemoryKind can be added and filtered."""
+    m = SharedMemory()
+    m.add(MemoryKind.PHYSICS_VERDICT, "check 5.1 PASS: dimensions OK")
+    m.add(MemoryKind.FIT_RESULT, "chi2=1.2")
+    entries = m.filter(MemoryKind.PHYSICS_VERDICT)
+    assert len(entries) == 1
+    assert "5.1 PASS" in entries[0].content
+
+
+# ---------------------------------------------------------------------------
+# Agent backward compatibility (gpd_tools=None)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_literature_agent_no_gpd_tools():
+    """LiteratureAgent works with gpd_tools=None (backward compat)."""
+    from mtf.agents.literature import LiteratureAgent
+
+    memory = SharedMemory()
+    agent = LiteratureAgent(
+        agent_id="lit-test",
+        model="claude-opus-4-6",
+        memory=memory,
+        gpd_tools=None,
+    )
+    # Agent should be created without errors; tools list should contain
+    # only arxiv + semantic search (no GPD tools)
+    assert agent._agent_id == "lit-test"
+    # The tools list should have exactly 2 (arxiv + semantic scholar)
+    assert len(agent._tools) == 2
+
+
+@pytest.mark.asyncio
+async def test_fitting_agent_no_gpd_tools():
+    """FittingAgent works with gpd_tools=None (backward compat)."""
+    from mtf.agents.fitting import FittingAgent
+
+    memory = SharedMemory()
+    toolkit = ToolkitRegistry()
+    agent = FittingAgent(
+        agent_id="fit-test",
+        model="claude-opus-4-6",
+        memory=memory,
+        toolkit=toolkit,
+        gpd_tools=None,
+    )
+    assert agent._agent_id == "fit-test"
+    # No GPD tools, so tools list should be empty
+    assert len(agent._tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_reviewer_agent_no_gpd_tools():
+    """ReviewerAgent works with gpd_tools=None (backward compat)."""
+    from mtf.agents.reviewer import ReviewerAgent
+
+    memory = SharedMemory()
+    agent = ReviewerAgent(
+        agent_id="rev-test",
+        model="claude-opus-4-6",
+        memory=memory,
+        gpd_tools=None,
+    )
+    assert agent._agent_id == "rev-test"
+    # No GPD tools, so tools list should be empty
+    assert len(agent._tools) == 0
+
+
+# ---------------------------------------------------------------------------
+# Debate engine — phase-conditional system prompts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory():
+    return SharedMemory()
+
+
+@pytest.fixture
+def config():
+    return MTFConfig()
+
+
+@pytest.mark.asyncio
+async def test_debate_system_prompt_literature_phase(memory, config):
+    """Literature phase does NOT get physics-first ranking criterion."""
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="literature")
+
+    system = captured["system"]
+    assert "ranking criterion" not in system
+    assert "literature" in system
+
+
+@pytest.mark.asyncio
+async def test_debate_system_prompt_fitting_phase(memory, config):
+    """Fitting phase DOES get physics-first ranking criterion."""
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="fitting")
+
+    system = captured["system"]
+    assert "ranking criterion" in system
+    assert "physical correctness" in system
+
+
+@pytest.mark.asyncio
+async def test_debate_system_prompt_review_phase(memory, config):
+    """Review phase DOES get physics-first ranking criterion."""
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="review")
+
+    system = captured["system"]
+    assert "ranking criterion" in system
+
+
+@pytest.mark.asyncio
+async def test_debate_includes_conventions_in_context(memory, config):
+    """Conventions entries appear in synthesis context."""
+    memory.add(MemoryKind.CONVENTIONS, "Fourier: exp(-iwt)")
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="fitting")
+
+    user_content = captured["messages"][0]["content"]
+    assert "Fourier: exp(-iwt)" in user_content
+    assert "Physics conventions in use" in user_content
+
+
+@pytest.mark.asyncio
+async def test_debate_includes_physics_verdicts_in_context(memory, config):
+    """Physics verdict entries appear in synthesis context."""
+    memory.add(MemoryKind.PHYSICS_VERDICT, "check 5.1 PASS: dimensions consistent")
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="review")
+
+    user_content = captured["messages"][0]["content"]
+    assert "check 5.1 PASS" in user_content
+    assert "Physics verification verdicts" in user_content
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults():
+    """New config fields have correct defaults."""
+    cfg = MTFConfig()
+    assert cfg.enable_gpd_mcp is True
+    assert cfg.physics_domain == "condensed_matter"
+    assert cfg.gpd_servers == [
+        "verification", "errors", "protocols", "conventions", "patterns"
+    ]


### PR DESCRIPTION
## What this PR does

Integrates [Get Physics Done (GPD)](https://github.com/psi-oss/get-physics-done) MCP servers into mtf's agent pipeline so that hypothesis selection is driven by **physical correctness** rather than chi-squared alone.

**Design principle**: use GPD's existing tools rather than reimplementing physics verification. GPD already ships 104 curated error classes, step-by-step protocols for 47+ domains, convention databases for 18 subfields, and structured verification checks — all exposed as callable MCP tools. mtf consumes them at runtime through a bridge layer.

Closes / addresses #1.

---

## Architecture overview

```
Orchestrator
  │
  ├─ GPDMCPClient.start()          5 MCP server subprocesses
  ├─ seed_patterns()               bootstrap ~/.gpd/ error pattern library
  │
  ├─ Literature Phase
  │   ├─ subfield_defaults() × N domains  →  MemoryKind.CONVENTIONS
  │   └─ LiteratureAgent × N
  │       ├─ [GPD tool] check_error_classes()   flag error-prone hypotheses
  │       └─ [GPD tool] route_protocol()        identify relevant methodology
  │
  ├─ Fitting Phase
  │   └─ FittingAgent × N×M
  │       ├─ [GPD tool] route_protocol()        find canonical methodology
  │       ├─ [GPD tool] get_protocol()          retrieve steps + checkpoints
  │       └─ [GPD tool] subfield_defaults()     correct conventions
  │           result dict gains: protocol_followed, physical_parameter_ranges,
  │                              protocol_checkpoints_satisfied
  │
  ├─ Review Phase
  │   └─ ReviewerAgent × K
  │       ├─ [GPD tool] check_error_classes()   surface known errors
  │       ├─ [GPD tool] get_checklist()         domain checklist
  │       ├─ [GPD tool] run_check(5.1/5.2/5.3/5.18)  structured PASS/FAIL
  │       ├─ [GPD tool] lookup_pattern()        cross-session recall
  │       └─ [GPD tool] add_pattern()           persist new errors
  │           output: SUPPORTED/PLAUSIBLE/SPECULATIVE/REJECTED + check IDs
  │
  └─ DebateEngine.synthesize()
      physics-first ranking: checks > parsimony > first-principles > chi²
      context includes: CONVENTIONS + PHYSICS_VERDICT entries
```

---

## Files changed

### New files
- **`mtf/tools/gpd_mcp.py`** — `GPDMCPClient` bridge. Runs GPD MCP servers as subprocesses in a dedicated background thread with its own event loop. `make_tool()` wraps MCP tools as `sdk.Tool` objects with proper `inspect.Signature` for JSON schema generation. `async_call()` offloads blocking waits to thread pool. Per-session `threading.Lock` for concurrent safety. Deferred thread creation (side-effect-free `__init__`).
- **`tests/test_gpd_integration.py`** — 14 test cases covering GPDMCPClient lifecycle, MemoryKind additions, agent backward compatibility, debate engine phase-conditional prompts, config defaults, and multi-domain config. All tests work without `get-physics-done` installed.

### Modified files
- **`mtf/config.py`** — Added `enable_gpd_mcp: bool`, `physics_domains: list[str]`, `gpd_servers: list[str]`
- **`mtf/memory.py`** — Added `CONVENTIONS` and `PHYSICS_VERDICT` to `MemoryKind`
- **`mtf/orchestrator.py`** — Creates/starts/closes `GPDMCPClient`; seeds patterns at startup; passes `gpd=` to all phases
- **`mtf/debate.py`** — Physics-first ranking criterion for fitting/review phases; injects CONVENTIONS and PHYSICS_VERDICT into synthesis context
- **`mtf/phases/literature_phase.py`** — Locks conventions per domain before fan-out; passes 2 GPD tools to LiteratureAgents
- **`mtf/phases/fitting_phase.py`** — Passes 3 GPD tools to all FittingAgents
- **`mtf/phases/review_phase.py`** — Passes 8 GPD tools to all ReviewerAgents
- **`mtf/agents/literature.py`** — Accepts `gpd_tools`; enriched prompt classifies hypotheses by physical basis
- **`mtf/agents/fitting.py`** — Accepts `gpd_tools`; enriched prompt follows GPD protocols and reports physical parameter ranges
- **`mtf/agents/reviewer.py`** — Accepts `gpd_tools`; enriched prompt runs structured verification checks and produces verdicts with check IDs
- **`mtf/cli.py`** — Added `--physics-domains`, `--no-gpd`, `--gpd-servers` flags
- **`pyproject.toml`** — Added `[gpd]` optional extra (`get-physics-done>=1.1.0`, `mcp>=1.26.0`)
- **`README.md`** — Mermaid diagram updated with GPD servers; agents table updated; new "GPD Physics Verification" section; installation/CLI/SharedMemory sections updated
- **`CLAUDE.md`** — GPD section rewritten with design-principle table; tool flow per agent; multi-domain docs; guidance to check GPD before reimplementing

---

## Why GPD servers instead of reimplementing

| Capability | GPD provides | What mtf would have to build without GPD |
|---|---|---|
| Physics error detection | 104 curated error classes with detection strategies | Encode error knowledge in system prompts per domain |
| Computation protocols | 47+ domain protocols with checkpoints | Write step-by-step instructions per domain in prompts |
| Convention locking | 18 standard fields across 14 subdomains | Track conventions manually in SharedMemory |
| Verification checks | Automated check IDs 5.1–5.19 with domain-specific issue detection | Build a custom verification framework |
| Cross-session memory | `~/.gpd/` pattern library with confidence promotion | Build a persistent store (database, filesystem) |

---

## Multi-domain support

`physics_domains` is a `list[str]` (not a single string), so cross-domain phenomena get conventions and checklists from all relevant domains:

```bash
mtf --physics-domains condensed_matter qft "topological insulator edge states"
mtf --physics-domains gr nuclear amo "neutron star cooling anomaly"
```

Convention locking iterates over all domains, storing one `MemoryKind.CONVENTIONS` entry per domain. ReviewerAgent's system prompt instructs `get_checklist` to be called once per domain and merge the results.

---

## Backward compatibility

- All agents: `gpd_tools=None` (default) preserves original behavior
- All phases: `gpd=None` (default) preserves original behavior
- `enable_gpd_mcp=True` but GPD not installed → graceful degradation, warning logged, pipeline runs normally
- No existing test behavior changed

---

## Test plan
- [ ] `pytest tests/test_gpd_integration.py -v` passes
- [ ] `pytest tests/test_memory.py tests/test_debate.py tests/test_phases.py -v` still passes
- [ ] `mtf --help` shows `--physics-domains`, `--no-gpd`, `--gpd-servers`
- [ ] `mtf --no-gpd "test"` runs without GPD
- [ ] `mtf --physics-domains qft gr "test"` locks conventions for both domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
