### PR TITLE
Add tests, CLI flags, and docs for GPD integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,24 @@ Each phase: fan-out agents with `asyncio.gather()` → collect reports → `Deba
 ### Concurrency
 Fitting agents are rate-limited by `asyncio.Semaphore(config.fitting_semaphore_limit)` (default 6) to avoid overwhelming the API when `fitting_scope="per_hypothesis"` spawns `N_hypotheses × M` concurrent agents.
 
+### GPD MCP Integration
+MTF optionally connects to [get-physics-done](https://github.com/FaroutYLq/get-physics-done) MCP servers for physics verification. Install with `pip install -e ".[dev,gpd]"`. Controlled by `config.enable_gpd_mcp` (default `True`; no-ops gracefully if the package is missing).
+
+**Servers** (defined in `mtf/tools/gpd_mcp.py`):
+- `verification` — structured physics checks (dimensional analysis 5.1, symmetry 5.2, limiting cases 5.3, fit-family mismatch 5.18)
+- `errors` — catalog of 104 known physics error classes with detection strategies
+- `protocols` — canonical computation protocols (step-by-step methodology with checkpoints)
+- `conventions` — subfield-specific sign conventions, Fourier transforms, natural units
+- `patterns` — persistent cross-session library of discovered physics error patterns
+
+**`GPDMCPClient`** runs a dedicated background event loop in a daemon thread. Each server is a subprocess communicating over stdio MCP protocol. `make_tool(server, tool_name, description)` returns an `sdk.Tool` (or `None` if unavailable), which phases filter into agent tool lists. `call(server, tool_name, **kwargs)` provides synchronous access for one-shot calls (e.g. seeding patterns at startup).
+
+**New `MemoryKind` values**:
+- `CONVENTIONS` — physics convention snapshot locked at the start of the literature phase; included in all agent prompt contexts
+- `PHYSICS_VERDICT` — structured check results from the verification server; injected into debate synthesis context
+
+**Pipeline flow**: conventions are locked once in the literature phase via `subfield_defaults`. All three agent types accept `gpd_tools: list | None` for backward compatibility. `DebateEngine.synthesize()` conditionally adds a physics-first ranking criterion to the system prompt for fitting and review phases (not literature). Conventions and physics verdicts from memory are appended to the user content block sent to the synthesis call.
+
 ## Key Invariants
 
 - All `HumanInterface` methods are async; never call `input()` directly.

--- a/mtf/cli.py
+++ b/mtf/cli.py
@@ -36,6 +36,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Input files to digest before analysis (images: PNG, JPG, GIF, WebP; documents: PDF)",
     )
     p.add_argument("--image-digest-model", default="claude-opus-4-6")
+
+    # GPD MCP integration
+    p.add_argument(
+        "--physics-domain",
+        default="condensed_matter",
+        metavar="DOMAIN",
+        help="Physics domain for GPD conventions (default: condensed_matter)",
+    )
+    p.add_argument(
+        "--no-gpd",
+        action="store_true",
+        help="Disable GPD MCP physics verification servers",
+    )
+    p.add_argument(
+        "--gpd-servers",
+        nargs="+",
+        metavar="SERVER",
+        default=None,
+        help="GPD MCP servers to start (default: all). "
+        "Choices: verification, errors, protocols, conventions, patterns",
+    )
     return p
 
 
@@ -51,6 +72,13 @@ def main() -> None:
         print("No phenomenon provided. Exiting.")
         sys.exit(1)
 
+    gpd_kwargs: dict[str, object] = {
+        "enable_gpd_mcp": not args.no_gpd,
+        "physics_domain": args.physics_domain,
+    }
+    if args.gpd_servers is not None:
+        gpd_kwargs["gpd_servers"] = args.gpd_servers
+
     config = MTFConfig(
         n_literature=args.n_literature,
         n_fitting=args.n_fitting,
@@ -61,6 +89,7 @@ def main() -> None:
         debate_model=args.debate_model,
         max_debate_rounds=args.max_debate_rounds,
         image_digest_model=args.image_digest_model,
+        **gpd_kwargs,  # type: ignore[arg-type]
     )
     orchestrator = MTFOrchestrator(config=config)
     asyncio.run(orchestrator.run(phenomenon, files=args.files or None))

--- a/tests/test_gpd_integration.py
+++ b/tests/test_gpd_integration.py
@@ -1,0 +1,288 @@
+"""Tests for GPD MCP integration.
+
+All tests work WITHOUT the get-physics-done package installed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mtf.config import MTFConfig
+from mtf.debate import DebateEngine
+from mtf.memory import MemoryKind, SharedMemory
+from mtf.toolkit.registry import ToolkitRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockInterface:
+    """Minimal mock of HumanInterface for tests."""
+
+    async def show(self, content: str, title: str = "") -> None:
+        pass
+
+    async def ask(self, prompt: str) -> str:
+        return ""
+
+    async def confirm(self, prompt: str) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# GPDMCPClient tests
+# ---------------------------------------------------------------------------
+
+
+def test_gpd_client_not_started_returns_empty():
+    """call() on a client that was never started returns empty string."""
+    from mtf.tools.gpd_mcp import GPDMCPClient
+
+    client = GPDMCPClient()
+    # Never called client.start(), so no sessions exist
+    result = client.call("verification", "get_checklist")
+    assert result == ""
+    client._loop.call_soon_threadsafe(client._loop.stop)
+    client._thread.join(timeout=5)
+
+
+def test_gpd_client_make_tool_unavailable_returns_none():
+    """make_tool() returns None when server is not in sessions."""
+    from mtf.tools.gpd_mcp import GPDMCPClient
+
+    client = GPDMCPClient()
+    tool = client.make_tool("verification", "get_checklist", "Get checklist")
+    assert tool is None
+    client._loop.call_soon_threadsafe(client._loop.stop)
+    client._thread.join(timeout=5)
+
+
+def test_gpd_client_available_false_before_start():
+    """client.available is False before start() is called."""
+    from mtf.tools.gpd_mcp import GPDMCPClient
+
+    client = GPDMCPClient()
+    assert client.available is False
+    client._loop.call_soon_threadsafe(client._loop.stop)
+    client._thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Memory tests
+# ---------------------------------------------------------------------------
+
+
+def test_memory_kind_conventions():
+    """CONVENTIONS MemoryKind can be added and filtered."""
+    m = SharedMemory()
+    m.add(MemoryKind.CONVENTIONS, "metric signature (-,+,+,+)")
+    m.add(MemoryKind.LITERATURE, "some paper")
+    entries = m.filter(MemoryKind.CONVENTIONS)
+    assert len(entries) == 1
+    assert entries[0].content == "metric signature (-,+,+,+)"
+    assert entries[0].kind == MemoryKind.CONVENTIONS
+
+
+def test_memory_kind_physics_verdict():
+    """PHYSICS_VERDICT MemoryKind can be added and filtered."""
+    m = SharedMemory()
+    m.add(MemoryKind.PHYSICS_VERDICT, "check 5.1 PASS: dimensions OK")
+    m.add(MemoryKind.FIT_RESULT, "chi2=1.2")
+    entries = m.filter(MemoryKind.PHYSICS_VERDICT)
+    assert len(entries) == 1
+    assert "5.1 PASS" in entries[0].content
+
+
+# ---------------------------------------------------------------------------
+# Agent backward compatibility (gpd_tools=None)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_literature_agent_no_gpd_tools():
+    """LiteratureAgent works with gpd_tools=None (backward compat)."""
+    from mtf.agents.literature import LiteratureAgent
+
+    memory = SharedMemory()
+    agent = LiteratureAgent(
+        agent_id="lit-test",
+        model="claude-opus-4-6",
+        memory=memory,
+        gpd_tools=None,
+    )
+    # Agent should be created without errors; tools list should contain
+    # only arxiv + semantic search (no GPD tools)
+    assert agent._agent_id == "lit-test"
+    # The tools list should have exactly 2 (arxiv + semantic scholar)
+    assert len(agent._tools) == 2
+
+
+@pytest.mark.asyncio
+async def test_fitting_agent_no_gpd_tools():
+    """FittingAgent works with gpd_tools=None (backward compat)."""
+    from mtf.agents.fitting import FittingAgent
+
+    memory = SharedMemory()
+    toolkit = ToolkitRegistry()
+    agent = FittingAgent(
+        agent_id="fit-test",
+        model="claude-opus-4-6",
+        memory=memory,
+        toolkit=toolkit,
+        gpd_tools=None,
+    )
+    assert agent._agent_id == "fit-test"
+    # No GPD tools, so tools list should be empty
+    assert len(agent._tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_reviewer_agent_no_gpd_tools():
+    """ReviewerAgent works with gpd_tools=None (backward compat)."""
+    from mtf.agents.reviewer import ReviewerAgent
+
+    memory = SharedMemory()
+    agent = ReviewerAgent(
+        agent_id="rev-test",
+        model="claude-opus-4-6",
+        memory=memory,
+        gpd_tools=None,
+    )
+    assert agent._agent_id == "rev-test"
+    # No GPD tools, so tools list should be empty
+    assert len(agent._tools) == 0
+
+
+# ---------------------------------------------------------------------------
+# Debate engine — phase-conditional system prompts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory():
+    return SharedMemory()
+
+
+@pytest.fixture
+def config():
+    return MTFConfig()
+
+
+@pytest.mark.asyncio
+async def test_debate_system_prompt_literature_phase(memory, config):
+    """Literature phase does NOT get physics-first ranking criterion."""
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="literature")
+
+    system = captured["system"]
+    assert "ranking criterion" not in system
+    assert "literature" in system
+
+
+@pytest.mark.asyncio
+async def test_debate_system_prompt_fitting_phase(memory, config):
+    """Fitting phase DOES get physics-first ranking criterion."""
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="fitting")
+
+    system = captured["system"]
+    assert "ranking criterion" in system
+    assert "physical correctness" in system
+
+
+@pytest.mark.asyncio
+async def test_debate_system_prompt_review_phase(memory, config):
+    """Review phase DOES get physics-first ranking criterion."""
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="review")
+
+    system = captured["system"]
+    assert "ranking criterion" in system
+
+
+@pytest.mark.asyncio
+async def test_debate_includes_conventions_in_context(memory, config):
+    """Conventions entries appear in synthesis context."""
+    memory.add(MemoryKind.CONVENTIONS, "Fourier: exp(-iwt)")
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="fitting")
+
+    user_content = captured["messages"][0]["content"]
+    assert "Fourier: exp(-iwt)" in user_content
+    assert "Physics conventions in use" in user_content
+
+
+@pytest.mark.asyncio
+async def test_debate_includes_physics_verdicts_in_context(memory, config):
+    """Physics verdict entries appear in synthesis context."""
+    memory.add(MemoryKind.PHYSICS_VERDICT, "check 5.1 PASS: dimensions consistent")
+    engine = DebateEngine(config, memory)
+    captured: dict = {}
+
+    def capture_call(**kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.content = [MagicMock(text="synthesis")]
+        return resp
+
+    with patch.object(engine._client.messages, "create", side_effect=capture_call):
+        await engine.synthesize(["report1"], phase="review")
+
+    user_content = captured["messages"][0]["content"]
+    assert "check 5.1 PASS" in user_content
+    assert "Physics verification verdicts" in user_content
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults():
+    """New config fields have correct defaults."""
+    cfg = MTFConfig()
+    assert cfg.enable_gpd_mcp is True
+    assert cfg.physics_domain == "condensed_matter"
+    assert cfg.gpd_servers == [
+        "verification", "errors", "protocols", "conventions", "patterns"
+    ]


### PR DESCRIPTION
## Summary

Addresses the critical and warning issues from the [Integration & Testing Review](https://github.com/FaroutYLq/mtf/pull/2#issuecomment-4099580749).

### Changes
- **Tests**: New `tests/test_gpd_integration.py` with 13+ test cases covering GPDMCPClient lifecycle, MemoryKind additions, agent backward compatibility, debate engine phase-conditional prompts, and config defaults. All tests work without `get-physics-done` installed.
- **CLI**: Added `--physics-domain`, `--no-gpd`, and `--gpd-servers` flags to `mtf/cli.py`
- **Docs**: Updated `CLAUDE.md` with GPD MCP Integration section

### Test plan
- [ ] `pytest tests/test_gpd_integration.py -v` passes
- [ ] `pytest tests/test_memory.py tests/test_debate.py tests/test_phases.py -v` still passes
- [ ] `mtf --help` shows new flags
- [ ] `mtf --no-gpd "test"` runs without GPD

🤖 Generated with [Claude Code](https://claude.com/claude-code)