### PR TITLE
Support multiple physics domains for cross-field phenomena

### DIFF
--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -13,8 +13,9 @@ fit results, and debate summaries, you:
 
 1. First call `check_error_classes` with the phenomenon description to identify the
    top-15 most relevant error classes to watch for.
-2. Call `get_checklist` with the physics domain (e.g. condensed_matter, qft, plasma,
-   amo) to retrieve the structured verification checklist.
+2. Call `get_checklist` for each physics domain listed in the conventions context
+   (e.g. condensed_matter, qft, plasma, amo). When the phenomenon spans multiple
+   domains, call it once per domain and merge the checklists.
 3. For each fit result, call `run_check` with the following mandatory check IDs,
    passing the fit result text as artifact_content:
    - "5.1" (dimensional consistency)

--- a/mtf/cli.py
+++ b/mtf/cli.py
@@ -36,6 +36,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Input files to digest before analysis (images: PNG, JPG, GIF, WebP; documents: PDF)",
     )
     p.add_argument("--image-digest-model", default="claude-opus-4-6")
+
+    # GPD MCP integration
+    p.add_argument(
+        "--physics-domains",
+        nargs="+",
+        default=["condensed_matter"],
+        metavar="DOMAIN",
+        help="Physics domains for GPD conventions and checklists, e.g. "
+        "'condensed_matter qft' for cross-domain phenomena (default: condensed_matter)",
+    )
+    p.add_argument(
+        "--no-gpd",
+        action="store_true",
+        help="Disable GPD MCP physics verification servers",
+    )
+    p.add_argument(
+        "--gpd-servers",
+        nargs="+",
+        metavar="SERVER",
+        default=None,
+        help="GPD MCP servers to start (default: all). "
+        "Choices: verification, errors, protocols, conventions, patterns",
+    )
     return p
 
 
@@ -51,6 +74,13 @@ def main() -> None:
         print("No phenomenon provided. Exiting.")
         sys.exit(1)
 
+    gpd_kwargs: dict[str, object] = {
+        "enable_gpd_mcp": not args.no_gpd,
+        "physics_domains": args.physics_domains,
+    }
+    if args.gpd_servers is not None:
+        gpd_kwargs["gpd_servers"] = args.gpd_servers
+
     config = MTFConfig(
         n_literature=args.n_literature,
         n_fitting=args.n_fitting,
@@ -61,6 +91,7 @@ def main() -> None:
         debate_model=args.debate_model,
         max_debate_rounds=args.max_debate_rounds,
         image_digest_model=args.image_digest_model,
+        **gpd_kwargs,  # type: ignore[arg-type]
     )
     orchestrator = MTFOrchestrator(config=config)
     asyncio.run(orchestrator.run(phenomenon, files=args.files or None))

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -31,7 +31,9 @@ class MTFConfig:
 
     # GPD MCP integration
     enable_gpd_mcp: bool = True
-    physics_domain: str = "condensed_matter"  # passed to get_checklist / subfield_defaults
+    physics_domains: list[str] = field(
+        default_factory=lambda: ["condensed_matter"],
+    )  # one or more domains; passed to get_checklist / subfield_defaults
     gpd_servers: list[str] = field(
         default_factory=lambda: ["verification", "errors", "protocols", "conventions", "patterns"]
     )

--- a/mtf/phases/literature_phase.py
+++ b/mtf/phases/literature_phase.py
@@ -38,13 +38,17 @@ async def run_literature_phase(
                 "Use to identify what methodology the literature should follow."),
         ] if t is not None]
 
-    # Lock physics conventions before the first fan-out
+    # Lock physics conventions before the first fan-out (one entry per domain)
     if gpd is not None:
-        conventions = gpd.call("conventions", "subfield_defaults", domain=config.physics_domain)
-        if conventions:
-            memory.add(MemoryKind.CONVENTIONS, conventions)
+        for domain in config.physics_domains:
+            conventions = gpd.call("conventions", "subfield_defaults", domain=domain)
+            if conventions:
+                memory.add(MemoryKind.CONVENTIONS, conventions, domain=domain)
+        locked = config.physics_domains
+        if locked:
+            domains_str = ", ".join(f"**{d}**" for d in locked)
             await interface.show(
-                f"Physics conventions locked for domain **{config.physics_domain}**.",
+                f"Physics conventions locked for: {domains_str}.",
                 title="MTF: GPD Conventions",
             )
 

--- a/mtf/phases/review_phase.py
+++ b/mtf/phases/review_phase.py
@@ -28,7 +28,9 @@ async def run_review_phase(
             gpd.make_tool("verification", "get_checklist",
                 "Get the domain-specific physics verification checklist. "
                 "Input: domain (str, e.g. condensed_matter, qft, gr, amo). "
-                "Returns list of check IDs and descriptions. Call this FIRST."),
+                "Returns list of check IDs and descriptions. Call this FIRST, "
+                "once per domain if the phenomenon spans multiple domains, "
+                "and merge the resulting checklists."),
             gpd.make_tool("verification", "run_check",
                 "Run a specific physics verification check against a fit result or hypothesis text. "
                 "Input: check_id (str: '5.1'=dimensional, '5.2'=symmetry, '5.3'=limiting_cases, "


### PR DESCRIPTION
## Summary

Fixes the physics review finding that `physics_domain` as a single string is inadequate for cross-domain phenomena (e.g. astroparticle physics, cavity QED, neutron star physics).

Changes `physics_domain: str` → `physics_domains: list[str]` throughout the codebase.

## What changed

- **`config.py`**: `physics_domain: str = "condensed_matter"` → `physics_domains: list[str] = ["condensed_matter"]`
- **`cli.py`**: `--physics-domains condensed_matter qft amo` accepts multiple values; also adds `--no-gpd` and `--gpd-servers` flags
- **`literature_phase.py`**: Convention locking iterates over all domains, storing one `MemoryKind.CONVENTIONS` entry per domain with `domain=` metadata
- **`reviewer.py`**: System prompt instructs `get_checklist` to be called once per domain and merge the checklists
- **`review_phase.py`**: Tool description for `get_checklist` mentions multi-domain usage

## Example usage

```bash
# Single domain (default, backward compatible)
mtf "anomalous resistivity in thin film"

# Cross-domain phenomenon
mtf --physics-domains condensed_matter qft "topological insulator edge states"

# Astroparticle physics
mtf --physics-domains gr nuclear amo "neutron star cooling anomaly"
```

## Test plan
- [ ] `MTFConfig().physics_domains` returns `["condensed_matter"]`
- [ ] `MTFConfig(physics_domains=["qft", "gr"]).physics_domains` returns both
- [ ] Convention locking stores one entry per domain in SharedMemory
- [ ] CLI `--physics-domains a b c` parses into a 3-element list

🤖 Generated with [Claude Code](https://claude.com/claude-code)