### PR TITLE
GPD deep integration: physics quality backbone throughout pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,19 +119,31 @@ Install with `pip install -e ".[dev,gpd]"`. Controlled by `config.enable_gpd_mcp
 | `protocols` | `route_protocol`, `get_protocol` | GPD provides canonical step-by-step methodology with checkpoints for each physics domain. FittingAgent follows these instead of inventing ad-hoc procedures. |
 | `conventions` | `subfield_defaults`, `convention_check` | GPD tracks 18 standard convention fields (metric signature, Fourier convention, natural units, gauge choice, etc.) across 14 subdomains. Prevents silent convention mismatches between agents. |
 | `patterns` | `lookup_pattern`, `add_pattern`, `seed_patterns` | GPD's `~/.gpd/` pattern store is the only persistent cross-session memory in the mtf pipeline. Errors found in one run surface in future runs on the same domain. |
+| `skills` | `list_skills`, `route_skill` | Used by `_classify_domains()` to auto-detect physics subfields from the phenomenon description; also available as an agent tool for capability discovery. |
 
 **`GPDMCPClient`** runs a dedicated background event loop in a daemon thread. Each server is a subprocess communicating over stdio MCP protocol. `make_tool(server, tool_name, description, params=)` returns an `sdk.Tool` (or `None` if unavailable), which phases filter into agent tool lists. `call(server, tool_name, **kwargs)` provides synchronous access for phase-level one-shot calls (e.g. convention locking, seeding patterns). `async_call()` offloads the blocking wait to a thread pool for use inside `asyncio.gather()` fan-outs.
 
 **How GPD tools flow to each agent**:
-- `LiteratureAgent` receives: `check_error_classes` (flag error-prone hypotheses), `route_protocol` (identify correct methodology)
-- `FittingAgent` receives: `route_protocol` + `get_protocol` (follow canonical procedure), `subfield_defaults` (correct conventions)
-- `ReviewerAgent` receives: all 8 tools above — `get_checklist`, `run_check` (5.1/5.2/5.3/5.18), `dimensional_check`, `limiting_case_check`, `check_error_classes`, `get_detection_strategy`, `lookup_pattern`, `add_pattern`
+- `LiteratureAgent` receives: `check_error_classes` (flag error-prone hypotheses), `route_protocol` (identify correct methodology), `lookup_pattern` (surface historical errors), `add_pattern` (record newly found systematic errors)
+- `FittingAgent` receives: `route_protocol` + `get_protocol` (follow canonical procedure), `subfield_defaults` (correct conventions), `convention_check` (pre-exec convention validation), `add_pattern` (record convergence failures)
+- `ReviewerAgent` receives: all verification tools — `get_checklist`, `run_check` (5.1/5.2/5.3/5.18), `dimensional_check`, `limiting_case_check`, `check_error_classes`, `get_detection_strategy`, `lookup_pattern`, `add_pattern`
 
 **`MemoryKind` values for GPD data**:
 - `CONVENTIONS` — physics convention snapshot locked per domain at the start of the literature phase; included in all agent prompt contexts
-- `PHYSICS_VERDICT` — structured check results from the verification server; injected into debate synthesis context
+- `PHYSICS_VERDICT` — structured check results from the verification server; written by the fitting phase (`_run_phase_physics_checks`), literature phase (plausibility screen), and debate engine (dimensional check postscript); injected into debate synthesis context
+- `FITTING_WARNINGS` — pre-dispatch pitfall warnings from pattern library + error class lookup; written by `_prefetch_fitting_warnings()` before the fitting fan-out; consumed by `FittingAgent` via `extra_kinds`
+- `DOMAIN_PATTERNS` — cross-session convention-pitfall patterns pre-fetched at literature phase start; consumed by `LiteratureAgent` and `FittingAgent` via `extra_kinds`
+- `DOMAIN_CLASSIFICATION` — audit trail of auto-detected physics domains; informational only, not consumed by agents
 
-**Pipeline flow**: conventions are locked once in the literature phase via `subfield_defaults` (called once per domain in `config.physics_domains`). All three agent types accept `gpd_tools: list | None` for backward compatibility. `DebateEngine.synthesize()` conditionally adds a physics-first ranking criterion to the system prompt for fitting and review phases (not literature). Conventions and physics verdicts from memory are appended to the user content block sent to the synthesis call.
+**Pipeline flow**: `MTFOrchestrator._classify_domains()` runs after `seed_patterns` and before the literature phase; it calls `route_protocol` and `route_skill` to detect physics domains from the phenomenon text and overwrites `config.physics_domains` ephemerally (controlled by `config.auto_detect_domains`). Conventions are then locked via `subfield_defaults` per domain; cross-session domain patterns are pre-fetched. Literature debate synthesis is followed by `_screen_hypothesis_plausibility()` which calls `limiting_case_check` per candidate hypothesis and shows `[PASS]/[WARN]/[FAIL]` badges before the user approval gate (`config.literature_plausibility_screen`). Before the fitting fan-out, `_prefetch_fitting_warnings()` queries `lookup_pattern` and `check_error_classes` per hypothesis. `FittingAgent.fit()` runs a `convention_check` on generated code before `exec()` and retries once on `FAIL` (`config.fitting_convention_check`, `config.fitting_max_convention_retries`). After the fitting fan-out, `_run_phase_physics_checks()` runs checks 5.1 and 5.3 per fit report and writes results to `PHYSICS_VERDICT`, so `DebateEngine.synthesize()` synthesises against real check data. For fitting and review phases, `DebateEngine` also runs a `dimensional_check` postscript on equation expressions extracted from the synthesis text and appends the result. All three agent types accept `gpd_tools: list | None` and `gpd: GPDMCPClient | None` for backward compatibility.
+
+**New `MTFConfig` fields** (all default to safe values so existing runs are unaffected):
+- `auto_detect_domains: bool = True` — enable `_classify_domains()` pre-flight
+- `gpd_domain_detection_max_domains: int = 4` — cap on auto-detected domains
+- `literature_plausibility_screen: bool = True` — enable `limiting_case_check` screen after literature debate
+- `auto_reject_physics_failures: bool = False` — if True, CRITICAL-FAIL hypotheses are filtered from the approved list
+- `fitting_convention_check: bool = True` — enable pre-exec `convention_check` in `FittingAgent.fit()`
+- `fitting_max_convention_retries: int = 1` — retries on convention FAIL before proceeding to `exec()`
 
 **When adding new physics capabilities to mtf**: check whether GPD already provides it as an MCP tool before implementing from scratch. The `gpd-mcp-skills` server (`list_skills`, `route_skill`) can discover available GPD capabilities programmatically.
 

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -99,8 +99,8 @@ image/document blocks can be placed in the content list alongside text blocks.
 |---|---|
 | **Phase** | ① Literature |
 | **API** | `sdk.query()` (agentic) |
-| **Tools** | arxiv search, Semantic Scholar, GPD: `check_error_classes`, `route_protocol` |
-| **Memory context read** | `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS` |
+| **Tools** | arxiv search, Semantic Scholar, GPD: `check_error_classes`, `route_protocol`, `lookup_pattern`, `add_pattern` |
+| **Memory context read** | `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `DOMAIN_PATTERNS` |
 | **Memory written** | `LITERATURE` |
 
 N instances run concurrently in each debate round (`asyncio.gather()`).
@@ -114,6 +114,11 @@ The system prompt instructs a fixed tool-call order:
 2. Search arxiv and Semantic Scholar thoroughly, prioritising recent, highly-cited work.
 3. For each proposed hypothesis, call `check_error_classes` to get the top-15 most likely
    physics error classes — error-prone approaches are flagged in the report.
+4. If systematic errors are found in a class of papers (convention-pitfalls, sign errors,
+   missing factors), call `add_pattern` to record them in the cross-session pattern store.
+
+The agent also receives `DOMAIN_PATTERNS` in context — pre-fetched pitfall patterns for the
+physics domain, written to memory before the fan-out.
 
 **Report structure produced:**
 
@@ -136,8 +141,8 @@ The report is stored as `LITERATURE` and returned to the phase for debate.
 |---|---|
 | **Phase** | ② Fitting |
 | **API** | `sdk.query()` (agentic) |
-| **Tools** | GPD: `route_protocol`, `get_protocol`, `subfield_defaults` |
-| **Memory context read** | `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS` |
+| **Tools** | GPD: `route_protocol`, `get_protocol`, `subfield_defaults`, `convention_check`, `add_pattern` |
+| **Memory context read** | `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS` |
 | **Memory written** | `FIT_RESULT` |
 
 M instances run per hypothesis, all rate-limited by `asyncio.Semaphore`.
@@ -146,6 +151,7 @@ M instances run per hypothesis, all rate-limited by `asyncio.Semaphore`.
 
 Asks the agent which data items and model functions are needed. Items prefixed with
 `MISSING:` in the response trigger an interactive toolkit-resolution loop in the phase.
+This probe also reads `FITTING_WARNINGS` and `DOMAIN_PATTERNS` from context.
 
 **`fit(hypothesis)` — agentic loop:**
 
@@ -157,6 +163,18 @@ The system prompt instructs:
 3. Call `subfield_defaults` with the relevant subfield to get canonical conventions
    (sign, Fourier, natural units, gauge) and embed them in the code.
 4. Write lmfit Python code following the protocol's checkpoints.
+5. If the fit fails to converge or produces unphysical parameters, call `add_pattern`
+   to record the convergence issue in the cross-session pattern store.
+
+The agent receives `FITTING_WARNINGS` and `DOMAIN_PATTERNS` in context — pre-fetched
+pitfall warnings for the specific hypothesis/domain combination, written before the fan-out.
+
+**Pre-exec convention check (phase-level, not agent-level):**
+
+After the agentic loop generates code, `fit()` calls `convention_check` on the generated
+code before `exec()`. If the check returns `FAIL`, the violation is written to
+`PHYSICS_VERDICT` and the agent retries once with the violation text in context
+(controlled by `config.fitting_convention_check` and `config.fitting_max_convention_retries`).
 
 The generated code is stripped of markdown fences, then executed by `run_fitting_code()`
 via `exec()` in a namespace seeded with `numpy`, `lmfit`, `scipy`, and the user's `data`

--- a/docs/architecture/gpd.md
+++ b/docs/architecture/gpd.md
@@ -6,13 +6,14 @@ Install with `pip install -e ".[gpd]"`. Controlled by `config.enable_gpd_mcp` (d
 
 ## GPD servers
 
-| Server | What MTF gets | Which agents call it |
-|--------|---------------|---------------------|
-| **verification** | Structured checks: dimensional (5.1), symmetry (5.2), limiting cases (5.3), fit-family (5.18) | `ReviewerAgent` |
-| **errors** | 104 curated error classes with detection strategies (sign errors, missing 2π factors, gauge artifacts, etc.) | `LiteratureAgent`, `ReviewerAgent` |
-| **protocols** | Step-by-step methodology with checkpoints for 47+ physics domains | `LiteratureAgent`, `FittingAgent` |
-| **conventions** | Canonical defaults for 18 subfields (Fourier convention, metric signature, natural units, gauge choice) | `FittingAgent` (via memory) |
-| **patterns** | Persistent cross-session error pattern library in `~/.gpd/` | `ReviewerAgent` |
+| Server | What MTF gets | Which agents / phases call it |
+|--------|---------------|-------------------------------|
+| **verification** | Structured checks: dimensional (5.1), symmetry (5.2), limiting cases (5.3), fit-family (5.18) | `_run_phase_physics_checks` (fitting phase), `_screen_hypothesis_plausibility` (literature phase), `DebateEngine` postscript, `ReviewerAgent` |
+| **errors** | 104 curated error classes with detection strategies (sign errors, missing 2π factors, gauge artifacts, etc.) | `LiteratureAgent`, `_prefetch_fitting_warnings` (fitting phase), `ReviewerAgent` |
+| **protocols** | Step-by-step methodology with checkpoints for 47+ physics domains | `LiteratureAgent`, `FittingAgent`, `_classify_domains` (orchestrator) |
+| **conventions** | Canonical defaults for 18 subfields (Fourier convention, metric signature, natural units, gauge choice) | Convention locking (literature phase), `FittingAgent` pre-exec check |
+| **patterns** | Persistent cross-session error pattern library in `~/.gpd/` | `_prefetch_domain_patterns` (literature phase), `_prefetch_fitting_warnings` (fitting phase), `LiteratureAgent`, `FittingAgent`, `ReviewerAgent` |
+| **skills** | Programmatic discovery of available GPD capabilities and physics domain routing | `_classify_domains` (orchestrator pre-flight) |
 
 ## Physics-first ranking
 
@@ -20,13 +21,45 @@ When GPD is active, `DebateEngine.synthesize()` adds a physics-first ranking cri
 
 > A model with χ²=1.5 that passes all verification checks ranks above χ²=0.9 with a dimensional analysis failure.
 
-## Convention locking
+For fitting and review phases, `DebateEngine` also extracts LaTeX/dimensional expressions from the synthesis text and calls `dimensional_check` as an objective postscript — appended to the synthesis and stored as `PHYSICS_VERDICT`.
 
-At the start of the literature phase, MTF calls `subfield_defaults` once per domain in `config.physics_domains` and stores the result as `MemoryKind.CONVENTIONS`. Every subsequent agent sees these conventions in their prompt context, preventing silent convention mismatches between agents.
+## Auto domain classification
+
+Before the literature phase, `MTFOrchestrator._classify_domains()` calls `route_protocol` and `route_skill` with the phenomenon description, parses known GPD domain names from the responses, and overwrites `config.physics_domains` for the run (ephemeral — no persistence). Falls back to the configured default if no domains are detected.
+
+Controlled by:
+- `config.auto_detect_domains: bool = True`
+- `config.gpd_domain_detection_max_domains: int = 4`
+
+The detected domains (or fallback notice) are written to `MemoryKind.DOMAIN_CLASSIFICATION` as an audit trail.
+
+## Convention locking and pre-exec validation
+
+At the start of the literature phase, MTF calls `subfield_defaults` once per domain in `config.physics_domains` and stores the result as `MemoryKind.CONVENTIONS`. Every subsequent agent sees these locked conventions in its prompt context, preventing silent mismatches (Fourier sign, metric signature, natural-unit choices) between agents.
+
+Additionally, `FittingAgent.fit()` calls `convention_check` on generated fitting code **before** `exec()` — a phase-level check separate from the agent's own `subfield_defaults` call. If the check returns `FAIL`, the violation is written to `PHYSICS_VERDICT` and the agent retries once with the violation text in context.
+
+Controlled by:
+- `config.fitting_convention_check: bool = True`
+- `config.fitting_max_convention_retries: int = 1`
+
+## Literature plausibility screening
+
+After each literature debate synthesis, `_screen_hypothesis_plausibility()` runs `limiting_case_check` on each candidate hypothesis (extracted from the synthesis text) with generic limits: `classical_limit`, `zero_coupling`, `large_N`. Results are shown to the user as `[PASS]` / `[WARN]` / `[FAIL]` badges before the approval gate, and stored as `PHYSICS_VERDICT`.
+
+If `config.auto_reject_physics_failures = True`, hypotheses receiving a `CRITICAL FAIL` verdict are filtered from the approved list (with a non-empty fallback in case all hypotheses fail).
+
+Controlled by:
+- `config.literature_plausibility_screen: bool = True`
+- `config.auto_reject_physics_failures: bool = False`
 
 ## Cross-session pattern memory
 
-`ReviewerAgent` calls `lookup_pattern` before reviewing and `add_pattern` after, using GPD's `~/.gpd/` store. Errors found in one run surface in future runs on the same domain — the only persistent cross-session memory in the MTF pipeline.
+GPD's `~/.gpd/` pattern store is the only persistent cross-session memory in the MTF pipeline. Patterns are used at three points:
+
+1. **Literature pre-fetch:** `_prefetch_domain_patterns()` calls `lookup_pattern(category="convention-pitfall")` per domain before the first literature fan-out. Results are stored as `DOMAIN_PATTERNS` and appear in `LiteratureAgent` prompt context.
+2. **Fitting pre-fetch:** `_prefetch_fitting_warnings()` calls `lookup_pattern(category="sign-error")`, `lookup_pattern(category="convergence-issue")`, and `check_error_classes` per hypothesis before the fitting fan-out. Results are stored as `FITTING_WARNINGS` and appear in `FittingAgent` prompt context.
+3. **Review and recording:** `ReviewerAgent` calls `lookup_pattern` before reviewing and `add_pattern` after finding new errors. `LiteratureAgent` and `FittingAgent` also have `add_pattern` as a tool to record systematic errors found during their work.
 
 ## Usage
 
@@ -50,5 +83,14 @@ mtf "..." --gpd-servers verification errors
 config = MTFConfig(
     enable_gpd_mcp=True,
     physics_domains=["condensed_matter", "qft"],
+    # Domain auto-detection
+    auto_detect_domains=True,
+    gpd_domain_detection_max_domains=4,
+    # Literature plausibility screen
+    literature_plausibility_screen=True,
+    auto_reject_physics_failures=False,
+    # Pre-exec convention validation
+    fitting_convention_check=True,
+    fitting_max_convention_retries=1,
 )
 ```

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -33,7 +33,10 @@ class MemoryEntry:
 | `FIT_RESULT` | `FittingAgent` | The `result` dict from one fitting agent's `exec()` run, formatted as text.  Carries `agent_id` and `hypothesis` metadata. |
 | `REVIEW` | `ReviewerAgent` | Full review report from one reviewer agent instance, including per-hypothesis SUPPORTED/PLAUSIBLE/SPECULATIVE/REJECTED verdicts with check IDs cited. |
 | `CONVENTIONS` | Literature phase (GPD) | Physics convention defaults for one subfield, returned by GPD `subfield_defaults`.  Carries `domain` metadata.  Locked once per session before the first literature fan-out. |
-| `PHYSICS_VERDICT` | Review phase (GPD) | Structured check results from GPD verification tools, stored if any check returns structured pass/fail data. |
+| `PHYSICS_VERDICT` | Fitting phase, literature phase, `DebateEngine` (all GPD) | Structured check results from GPD verification tools.  Written by: `_run_phase_physics_checks` (checks 5.1 + 5.3 per fit report), `_screen_hypothesis_plausibility` (limiting-case screen), `FittingAgent.fit()` (pre-exec convention check), and `DebateEngine` (dimensional check postscript for fitting/review phases).  Injected into every debate synthesis context. |
+| `FITTING_WARNINGS` | Fitting phase (GPD) | Pre-dispatch pitfall warnings combining domain `lookup_pattern` results (sign-error, convergence-issue categories) and `check_error_classes` output per hypothesis.  Written by `_prefetch_fitting_warnings()` before the fitting fan-out.  Carries `domain` and `hypothesis` metadata. |
+| `DOMAIN_PATTERNS` | Literature phase (GPD) | Cross-session convention-pitfall patterns pre-fetched before the first literature fan-out via `lookup_pattern(category="convention-pitfall")`.  Carries `domain` and `source` metadata. |
+| `DOMAIN_CLASSIFICATION` | `MTFOrchestrator._classify_domains()` | Audit trail of auto-detected physics domains when `config.auto_detect_domains=True`.  Records either the detected list or a fallback notice.  Informational only — not consumed by agents via `extra_kinds`. |
 | `TOOLKIT_DIGEST` | `ToolBuilderAgent` | Summary of data and model items parsed from complex user-supplied input by the tool-builder agent. |
 
 ---
@@ -70,9 +73,9 @@ Task: Investigate the following experimental phenomenon …
 
 | Agent | `extra_kinds` passed to `_query()` |
 |-------|-----------------------------------|
-| `LiteratureAgent.investigate()` | `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS` |
-| `FittingAgent.identify_needed_toolkit_items()` | `LITERATURE`, `DEBATE`, `IMAGE_DATA`, `CONVENTIONS` |
-| `FittingAgent.fit()` | `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS` |
+| `LiteratureAgent.investigate()` | `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `DOMAIN_PATTERNS` |
+| `FittingAgent.identify_needed_toolkit_items()` | `LITERATURE`, `DEBATE`, `IMAGE_DATA`, `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS` |
+| `FittingAgent.fit()` | `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS` |
 | `ReviewerAgent.review()` | `LITERATURE`, `DEBATE`, `FIT_RESULT`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT` |
 
 `DebateEngine.synthesize()` always calls `memory.format_context()` with no arguments,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -17,31 +17,35 @@ flowchart TD
         GP["protocols\n47+ domain protocols"]
         GC["conventions\n18 subfields"]
         GPat["patterns\ncross-session memory"]
+        GS["skills\ndomain discovery"]
     end
 
     subgraph LIT ["① LITERATURE PHASE"]
         direction TB
-        LC["Lock conventions\nvia GPD subfield_defaults"]
-        L["L1 · L2 · L3\nN parallel agents\narxiv + Semantic Scholar\n+ GPD: check_error_classes, route_protocol"]
-        LD["🔀 Debate\nsynthesis call"]
+        LC["Auto domain classification\n+ lock conventions via GPD subfield_defaults\n+ pre-fetch DOMAIN_PATTERNS"]
+        L["L1 · L2 · L3\nN parallel agents\narxiv + Semantic Scholar\n+ GPD: check_error_classes, route_protocol,\nlookup_pattern, add_pattern"]
+        LD["🔀 Debate\nsynthesis call + dimensional check postscript"]
+        LS["Plausibility screen\nlimiting_case_check per hypothesis"]
         LU{"User approval"}
-        LC --> L --> LD --> LU
+        LC --> L --> LD --> LS --> LU
         LU -->|"reject: add feedback"| L
     end
 
     subgraph FIT ["② FITTING PHASE  —  per approved hypothesis"]
         direction TB
+        FW["Pre-fetch FITTING_WARNINGS\nlookup_pattern + check_error_classes per hypothesis"]
         FT["toolkit check\n(request missing data from user)"]
-        F["F1 · F2 · F3\nM parallel agents\nlmfit + numpy/scipy\n+ GPD: route_protocol, get_protocol, subfield_defaults"]
-        FD["🔀 Debate\nphysics-first ranking"]
+        F["F1 · F2 · F3\nM parallel agents\nlmfit + numpy/scipy\n+ GPD: route_protocol, get_protocol,\nsubfield_defaults, convention_check, add_pattern"]
+        FC["Phase physics checks\nrun_check 5.1 + 5.3 per fit result → PHYSICS_VERDICT"]
+        FD["🔀 Debate\nphysics-first ranking + dimensional check postscript"]
         FU{"User approval"}
-        FT --> F --> FD --> FU
+        FW --> FT --> F --> FC --> FD --> FU
     end
 
     subgraph REV ["③ REVIEW PHASE"]
         direction TB
         R["R1 · R2 · R3\nK parallel agents\n+ GPD: get_checklist, run_check, check_error_classes,\nlookup_pattern, add_pattern"]
-        RD["🔀 Debate\nphysics-first ranking"]
+        RD["🔀 Debate\nphysics-first ranking + dimensional check postscript"]
         R --> RD
     end
 
@@ -99,13 +103,26 @@ an `image` or `document` block with a `text` block in the same user message.
 
 ## Phase 1: Literature
 
-### Convention locking (once per session)
+### Pre-flight (before first fan-out)
 
-Before the first fan-out, the phase calls GPD `subfield_defaults` once per domain in
-`config.physics_domains` and stores each result as `MemoryKind.CONVENTIONS`.  Every subsequent
-agent — across all three phases — sees these locked conventions in its prompt context,
-preventing silent mismatches (Fourier sign, metric signature, natural-unit choices, etc.)
-between agents working on the same phenomenon.
+Before the first fan-out, three setup steps run once:
+
+1. **Auto domain classification:** `MTFOrchestrator._classify_domains()` calls GPD
+   `route_protocol` and `route_skill` with the phenomenon description, parses known domain
+   names from the responses, and overwrites `config.physics_domains` for the run (ephemeral —
+   no persistence). Falls back to the configured default if no domains are detected. The
+   detected domains (or fallback notice) are stored as `DOMAIN_CLASSIFICATION` for audit.
+   Controlled by `config.auto_detect_domains` (default `True`).
+
+2. **Convention locking:** The phase calls GPD `subfield_defaults` once per domain in
+   `config.physics_domains` and stores each result as `MemoryKind.CONVENTIONS`.  Every subsequent
+   agent — across all three phases — sees these locked conventions in its prompt context,
+   preventing silent mismatches (Fourier sign, metric signature, natural-unit choices, etc.)
+   between agents working on the same phenomenon.
+
+3. **Domain pattern pre-fetch:** `_prefetch_domain_patterns()` calls `lookup_pattern` with
+   `category="convention-pitfall"` per domain, storing results as `DOMAIN_PATTERNS`.  These
+   cross-session patterns appear in every `LiteratureAgent` prompt context automatically.
 
 ### Debate loop
 
@@ -114,15 +131,17 @@ The phase runs up to `config.max_debate_rounds` iterations:
 1. **Fan-out:** `N` `LiteratureAgent` instances are created and all `investigate()` calls run
    concurrently via `asyncio.gather()`.  Each agent:
    - Prepends a `SharedMemory` context block to its prompt (containing `USER_FEEDBACK`,
-     `IMAGE_DATA`, and `CONVENTIONS` entries).
+     `IMAGE_DATA`, `CONVENTIONS`, and `DOMAIN_PATTERNS` entries).
    - Calls `sdk.query()` (an agentic streaming loop) with tools: arxiv search,
-     Semantic Scholar, and GPD `check_error_classes` + `route_protocol`.
+     Semantic Scholar, and GPD `check_error_classes`, `route_protocol`, `lookup_pattern`,
+     `add_pattern`.
    - Inside the agentic loop, the model may invoke tools multiple times before producing
      its final text response.
    - The system prompt instructs the agent to: (a) call `route_protocol` first, (b) search
      both databases, (c) call `check_error_classes` for each proposed hypothesis, (d) produce
      a structured report classifying each hypothesis by basis (first-principles / semi-empirical /
-     empirical), verification status, and known failure modes.
+     empirical), verification status, and known failure modes, (e) call `add_pattern` for any
+     systematic errors found in a class of papers.
    - The final report is stored as `MemoryKind.LITERATURE`.
 
 2. **Debate:** `DebateEngine.synthesize(phase="literature")` collects all N reports and
@@ -130,16 +149,23 @@ The phase runs up to `config.max_debate_rounds` iterations:
    instructs the model to resolve contradictions and surface the strongest hypotheses.
    No physics-first ranking criterion is added for the literature phase.
 
-3. **User approval:** The synthesis is displayed. If the user approves, hypothesis lines
-   are extracted (lines containing the keywords `hypothesis`, `proposed`, `model`, or
-   `theory`) and stored as `MemoryKind.HYPOTHESIS`.  The phase returns those hypothesis
-   strings to the orchestrator.
+3. **Plausibility screen:** `_screen_hypothesis_plausibility()` extracts candidate
+   hypotheses from the synthesis text and runs `limiting_case_check` on each
+   (`classical_limit`, `zero_coupling`, `large_N`) via `asyncio.gather()`.  Results are shown
+   to the user as `[PASS]` / `[WARN]` / `[FAIL]` badges before the approval gate, and written
+   as `PHYSICS_VERDICT`.  If `config.auto_reject_physics_failures=True`, CRITICAL-FAIL
+   hypotheses are removed from the approved list (with a non-empty fallback).
 
-4. **Rejection:** If the user rejects, they are asked for guidance, which is stored as
+4. **User approval:** The synthesis and plausibility badges are displayed. If the user
+   approves, hypothesis lines are extracted (lines containing the keywords `hypothesis`,
+   `proposed`, `model`, or `theory`) and stored as `MemoryKind.HYPOTHESIS`.  The phase returns
+   those hypothesis strings to the orchestrator.
+
+5. **Rejection:** If the user rejects, they are asked for guidance, which is stored as
    `MemoryKind.USER_FEEDBACK`.  The loop repeats from step 1 — the new agents will see
    the feedback in their prompt context.
 
-5. **Max-rounds fallback:** If `max_debate_rounds` is exhausted without explicit approval,
+6. **Max-rounds fallback:** If `max_debate_rounds` is exhausted without explicit approval,
    the last synthesis is used and the pipeline continues.
 
 ---
@@ -160,6 +186,17 @@ User-provided values are handled on two paths:
   to produce structured `data_items` and `model_items`, then registers them in
   `ToolkitRegistry`.  On failure, the raw string is stored as a fallback.
 
+### Pre-dispatch warnings (before fan-out)
+
+`_prefetch_fitting_warnings()` runs before any fitting agent starts.  For each
+`(domain, hypothesis)` pair it fans out:
+- `lookup_pattern(domain, "sign-error", hypothesis[:200])`
+- `lookup_pattern(domain, "convergence-issue", hypothesis[:200])`
+- `check_error_classes(description=hypothesis[:500])`
+
+Results are stored as `FITTING_WARNINGS` and appear in every `FittingAgent` prompt context
+automatically, giving agents advance warning of known pitfalls for that model type.
+
 ### Fan-out and rate limiting
 
 Fitting agents are launched under `asyncio.Semaphore(config.fitting_semaphore_limit)`
@@ -172,17 +209,29 @@ Fitting agents are launched under `asyncio.Semaphore(config.fitting_semaphore_li
 
 Each `FittingAgent.fit()`:
 1. Prepends memory context (`LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `IMAGE_DATA`,
-   `CONVENTIONS`) to the prompt.
+   `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS`) to the prompt.
 2. Calls `sdk.query()` — the agentic loop calls GPD tools in order:
    `route_protocol` → `get_protocol` → `subfield_defaults`.
 3. Generates lmfit Python code following the retrieved protocol's checkpoints.
-4. Strips markdown code fences, then passes the code to `run_fitting_code()`, which
+4. **Pre-exec convention check:** calls `convention_check` on the generated code before
+   `exec()`.  On `FAIL`, the violation is written to `PHYSICS_VERDICT` and the agent retries
+   once with the violation text in context (controlled by `config.fitting_convention_check`
+   and `config.fitting_max_convention_retries`).
+5. Strips markdown code fences, then passes the code to `run_fitting_code()`, which
    `exec()`s it in a namespace pre-seeded with `numpy`, `lmfit`, `scipy`, and the
    user's `data` dict from `ToolkitRegistry`.  The code must assign its output to `result`.
-5. The `result` dict must include: `parameters`, `uncertainties`, `chi_squared`,
+6. The `result` dict must include: `parameters`, `uncertainties`, `chi_squared`,
    `reduced_chi_squared`, `assessment`, `protocol_followed`, `physical_parameter_ranges`,
    and `protocol_checkpoints_satisfied`.
-6. The fit output is stored as `MemoryKind.FIT_RESULT`.
+7. The fit output is stored as `MemoryKind.FIT_RESULT`.
+
+### Phase physics checks (after fan-out)
+
+After all fitting agents complete, `_run_phase_physics_checks()` runs checks 5.1
+(dimensional consistency) and 5.3 (limiting cases) on each fit report via
+`asyncio.gather()`.  Non-empty results are stored as `PHYSICS_VERDICT` entries with
+`source="phase_physics_check"`.  These populate the `PHYSICS_VERDICT` context block that
+`DebateEngine` injects into the synthesis call.
 
 ### Debate and approval
 
@@ -195,8 +244,10 @@ system prompt adds a physics-first ranking criterion:
 > 3. First-principles basis
 > 4. Chi² (tiebreaker only)
 
-The `CONVENTIONS` and `PHYSICS_VERDICT` memory entries are appended to the user content block
-sent to the synthesis call.
+The `CONVENTIONS` and `PHYSICS_VERDICT` memory entries (now populated by the phase checks)
+are appended to the user content block sent to the synthesis call.  After the synthesis,
+`DebateEngine` extracts LaTeX/dimensional expressions from the text and appends an objective
+dimensional check postscript (stored as both part of `DEBATE` and as `PHYSICS_VERDICT`).
 
 The fitting synthesis is shown to the user.  If rejected, feedback is stored and the pipeline
 continues regardless (there is no retry loop in the fitting phase).
@@ -246,8 +297,16 @@ The call constructs its user content block by concatenating:
 The system prompt is phase-dependent: for `"fitting"` and `"review"` phases, the
 four-criterion physics-first ranking paragraph is appended.  For `"literature"` it is omitted.
 
-The synthesis output is stored as `MemoryKind.DEBATE` with a `phase` metadata tag, making
-it visible to all subsequent agents via `_build_prompt()`.
+**Dimensional check postscript (fitting and review phases only):** After the `messages.create()`
+call, `DebateEngine._append_dimensional_check()` extracts LaTeX inline equations (`$...$`) and
+dimensional expressions (`[M][L]...`) from the synthesis text (up to 5 candidates) and calls
+`dimensional_check` on them.  The result is appended to the synthesis as an
+`--- OBJECTIVE DIMENSIONAL CHECK ---` block and also stored as `PHYSICS_VERDICT` with
+`source="debate_dimensional_check"`.  This is a pure postscript — no second LLM call — and is
+intentionally embedded in the `DEBATE` entry so downstream agents see it alongside the synthesis.
+
+The synthesis output (including any postscript) is stored as `MemoryKind.DEBATE` with a `phase`
+metadata tag, making it visible to all subsequent agents via `_build_prompt()`.
 
 ---
 

--- a/mtf/agents/fitting.py
+++ b/mtf/agents/fitting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from mtf.agents.base import BaseAgent
@@ -145,8 +146,10 @@ class FittingAgent(BaseAgent):
                 else "condensed_matter"
             )
             for attempt in range(self._config.fitting_max_convention_retries + 1):
-                check_result = self._gpd.call(
-                    "conventions", "convention_check",
+                # Use asyncio.to_thread so the blocking MCP call doesn't stall the event loop
+                # when multiple fitting agents run concurrently under the semaphore.
+                check_result = await asyncio.to_thread(
+                    self._gpd.call, "conventions", "convention_check",
                     expression=code[:2000], domain=domain,
                 )
                 if check_result and "FAIL" in check_result.upper():

--- a/mtf/agents/fitting.py
+++ b/mtf/agents/fitting.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
 from mtf.toolkit.registry import ToolkitRegistry
 from mtf.tools.fitting_tools import run_fitting_code
+
+if TYPE_CHECKING:
+    from mtf.config import MTFConfig
+    from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """You are an expert data analysis and model fitting agent for
 experimental physics. Given a hypothesis and experimental data, you:
@@ -32,8 +36,27 @@ experimental physics. Given a hypothesis and experimental data, you:
    parameters with uncertainties, and an assessment of whether the hypothesis is
    supported. Chi-squared is a necessary metric but NOT the sole quality criterion;
    physical correctness (parameter bounds, limiting cases, symmetry) matters more.
+8. If your fitting code fails to converge or produces unphysical parameters, call
+   `add_pattern(category='convergence-issue', ...)` to record the pattern for future
+   runs on this domain.
 
 Always write clean, well-commented fitting code."""
+
+
+def _strip_fences(code: str) -> str:
+    """Strip markdown code fences from a code string."""
+    if "```" not in code:
+        return code
+    lines = code.splitlines()
+    code_lines = []
+    in_block = False
+    for line in lines:
+        if line.strip().startswith("```"):
+            in_block = not in_block
+            continue
+        if in_block:
+            code_lines.append(line)
+    return "\n".join(code_lines)
 
 
 class FittingAgent(BaseAgent):
@@ -44,6 +67,8 @@ class FittingAgent(BaseAgent):
         memory: SharedMemory,
         toolkit: ToolkitRegistry,
         gpd_tools: list[Any] | None = None,
+        gpd: GPDMCPClient | None = None,
+        config: MTFConfig | None = None,
     ) -> None:
         extra_tools: list[Any] = gpd_tools if gpd_tools is not None else []
         super().__init__(
@@ -54,6 +79,8 @@ class FittingAgent(BaseAgent):
             system_prompt=_SYSTEM_PROMPT,
         )
         self._toolkit = toolkit
+        self._gpd = gpd
+        self._config = config
 
     async def identify_needed_toolkit_items(self, hypothesis: str) -> list[str]:
         """Ask the agent which toolkit items it needs to fit this hypothesis."""
@@ -70,6 +97,8 @@ class FittingAgent(BaseAgent):
                 MemoryKind.DEBATE,
                 MemoryKind.IMAGE_DATA,
                 MemoryKind.CONVENTIONS,
+                MemoryKind.FITTING_WARNINGS,
+                MemoryKind.DOMAIN_PATTERNS,
             ),
         )
         lines = [l.strip() for l in response.splitlines() if l.strip()]
@@ -97,20 +126,56 @@ class FittingAgent(BaseAgent):
                 MemoryKind.USER_FEEDBACK,
                 MemoryKind.IMAGE_DATA,
                 MemoryKind.CONVENTIONS,
+                MemoryKind.FITTING_WARNINGS,
+                MemoryKind.DOMAIN_PATTERNS,
             ),
         )
-        # Strip markdown code fences if present
-        if "```" in code:
-            lines = code.splitlines()
-            code_lines = []
-            in_block = False
-            for line in lines:
-                if line.strip().startswith("```"):
-                    in_block = not in_block
-                    continue
-                if in_block:
-                    code_lines.append(line)
-            code = "\n".join(code_lines)
+        code = _strip_fences(code)
+
+        # Pre-exec convention check (Addition 3): check generated code for convention
+        # violations before running it; retry once if violations are found.
+        if (
+            self._gpd is not None
+            and self._config is not None
+            and self._config.fitting_convention_check
+        ):
+            domain = (
+                self._config.physics_domains[0]
+                if self._config.physics_domains
+                else "condensed_matter"
+            )
+            for attempt in range(self._config.fitting_max_convention_retries + 1):
+                check_result = self._gpd.call(
+                    "conventions", "convention_check",
+                    expression=code[:2000], domain=domain,
+                )
+                if check_result and "FAIL" in check_result.upper():
+                    self._memory.add(
+                        MemoryKind.PHYSICS_VERDICT,
+                        check_result,
+                        source="convention_check_pre_exec",
+                        hypothesis=hypothesis[:200],
+                    )
+                    if attempt < self._config.fitting_max_convention_retries:
+                        retry_task = (
+                            f"{task}\n\nConvention check FAIL (attempt {attempt + 1}):\n"
+                            f"{check_result}\n\nPlease fix all convention violations."
+                        )
+                        code = await self._query(
+                            retry_task,
+                            extra_kinds=(
+                                MemoryKind.LITERATURE,
+                                MemoryKind.DEBATE,
+                                MemoryKind.USER_FEEDBACK,
+                                MemoryKind.IMAGE_DATA,
+                                MemoryKind.CONVENTIONS,
+                                MemoryKind.FITTING_WARNINGS,
+                                MemoryKind.DOMAIN_PATTERNS,
+                            ),
+                        )
+                        code = _strip_fences(code)
+                else:
+                    break  # No violation — proceed to exec
 
         fit_output = run_fitting_code(code, self._toolkit.all_data())
         report = f"Hypothesis: {hypothesis}\n\nFit output: {fit_output}"

--- a/mtf/agents/literature.py
+++ b/mtf/agents/literature.py
@@ -29,6 +29,9 @@ the experimental phenomenon provided by the user.
       - Known failure modes: from check_error_classes results
    d. Key equations or models from the literature
    e. Error-prone aspects flagged per hypothesis based on check_error_classes results
+5. When you find a systematic error pattern in a class of papers (wrong conventions,
+   missing factors, sign errors), call `add_pattern(category='convention-pitfall', ...)`
+   to record it in the cross-session pattern store for future runs.
 
 Prefer first-principles hypotheses over phenomenological curve fits. Be precise, cite
 paper titles and authors."""
@@ -63,6 +66,7 @@ class LiteratureAgent(BaseAgent):
                 MemoryKind.USER_FEEDBACK,
                 MemoryKind.IMAGE_DATA,
                 MemoryKind.CONVENTIONS,
+                MemoryKind.DOMAIN_PATTERNS,
             ),
         )
         self._memory.add(

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -35,5 +35,14 @@ class MTFConfig:
         default_factory=lambda: ["condensed_matter"],
     )  # one or more domains; passed to get_checklist / subfield_defaults
     gpd_servers: list[str] = field(
-        default_factory=lambda: ["verification", "errors", "protocols", "conventions", "patterns"]
+        default_factory=lambda: ["verification", "errors", "protocols", "conventions", "patterns", "skills"]
     )
+    # Auto domain classification (Addition 1)
+    auto_detect_domains: bool = True
+    gpd_domain_detection_max_domains: int = 4
+    # Literature plausibility screen (Addition 5)
+    literature_plausibility_screen: bool = True
+    auto_reject_physics_failures: bool = False
+    # Fitting convention check (Addition 3)
+    fitting_convention_check: bool = True
+    fitting_max_convention_retries: int = 1

--- a/mtf/debate.py
+++ b/mtf/debate.py
@@ -2,19 +2,31 @@
 
 from __future__ import annotations
 
+import re
+from typing import TYPE_CHECKING, Any
+
 import anthropic
 
 from mtf.config import MTFConfig
 from mtf.memory import MemoryKind, SharedMemory
 
+if TYPE_CHECKING:
+    from mtf.tools.gpd_mcp import GPDMCPClient
+
 
 class DebateEngine:
     """Single-shot Anthropic API call that synthesizes N agent reports."""
 
-    def __init__(self, config: MTFConfig, memory: SharedMemory) -> None:
+    def __init__(
+        self,
+        config: MTFConfig,
+        memory: SharedMemory,
+        gpd: GPDMCPClient | None = None,
+    ) -> None:
         self._config = config
         self._memory = memory
         self._client = anthropic.Anthropic()
+        self._gpd = gpd
 
     async def synthesize(
         self,
@@ -25,6 +37,8 @@ class DebateEngine:
         """Synthesize reports from multiple agents into one summary.
 
         Not an agentic call — a plain messages.create() for speed.
+        For fitting and review phases, appends an objective dimensional check
+        postscript using GPD if available (Addition 8).
         """
         import asyncio
 
@@ -84,5 +98,36 @@ class DebateEngine:
             messages=[{"role": "user", "content": user_content}],
         )
         summary: str = response.content[0].text  # type: ignore[index]
+
+        # Addition 8: dimensional check postscript — objective, no second LLM call.
+        if self._gpd is not None and phase in ("fitting", "review"):
+            summary = await self._append_dimensional_check(summary, phase)
+
         self._memory.add(MemoryKind.DEBATE, summary, phase=phase)
+        return summary
+
+    async def _append_dimensional_check(self, summary: str, phase: str) -> str:
+        """Extract equations from summary and run dimensional_check as a postscript."""
+        import asyncio
+
+        # Extract LaTeX inline equations and dimensional expressions (max 5 candidates)
+        latex_exprs = re.findall(r'\$([^$]{3,100})\$', summary)
+        dim_exprs = re.findall(r'\[[A-Z]\][^\n.]{0,60}', summary)
+        candidates = (latex_exprs + dim_exprs)[:5]
+        if not candidates:
+            return summary
+
+        check_result = await asyncio.to_thread(
+            self._gpd.call, "verification", "dimensional_check",
+            expressions=candidates,
+        )
+        if check_result:
+            self._memory.add(
+                MemoryKind.PHYSICS_VERDICT,
+                check_result,
+                source="debate_dimensional_check",
+                phase=phase,
+            )
+            summary = summary + "\n\n--- OBJECTIVE DIMENSIONAL CHECK ---\n" + check_result
+
         return summary

--- a/mtf/debate.py
+++ b/mtf/debate.py
@@ -100,6 +100,10 @@ class DebateEngine:
         summary: str = response.content[0].text  # type: ignore[index]
 
         # Addition 8: dimensional check postscript — objective, no second LLM call.
+        # The postscript is intentionally embedded in the DEBATE memory entry so that
+        # downstream agents reading MemoryKind.DEBATE see the objective check alongside
+        # the synthesis.  The same result is also stored as PHYSICS_VERDICT for targeted
+        # filtering in the review phase.
         if self._gpd is not None and phase in ("fitting", "review"):
             summary = await self._append_dimensional_check(summary, phase)
 

--- a/mtf/memory.py
+++ b/mtf/memory.py
@@ -19,6 +19,9 @@ class MemoryKind(str, Enum):
     # GPD MCP integration
     CONVENTIONS = "conventions"        # physics convention lock from gpd-conventions
     PHYSICS_VERDICT = "physics_verdict"  # structured check results from gpd-verification
+    FITTING_WARNINGS = "fitting_warnings"  # pre-dispatch pitfall warnings from pattern library + error classes
+    DOMAIN_PATTERNS = "domain_patterns"    # cross-session patterns pre-fetched at literature phase start
+    DOMAIN_CLASSIFICATION = "domain_classification"  # auto-detected domain classification (audit trail)
 
 
 @dataclass

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -2,18 +2,32 @@
 
 from __future__ import annotations
 
+import asyncio
+import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from mtf.agents.image_digest import ImageDigestAgent
 from mtf.config import MTFConfig
 from mtf.debate import DebateEngine
 from mtf.interface import CLIInterface, HumanInterface
-from mtf.memory import SharedMemory
+from mtf.memory import MemoryKind, SharedMemory
 from mtf.phases.fitting_phase import run_fitting_phase
 from mtf.phases.literature_phase import run_literature_phase
 from mtf.phases.review_phase import run_review_phase
 from mtf.toolkit.registry import ToolkitRegistry
 from mtf.tools.gpd_mcp import GPDMCPClient
+
+if TYPE_CHECKING:
+    pass
+
+# Known GPD physics domain identifiers used for auto-classification.
+_KNOWN_DOMAINS: frozenset[str] = frozenset([
+    "condensed_matter", "qft", "gr", "amo", "plasma",
+    "nuclear", "particle_physics", "cosmology", "optics",
+    "fluid_dynamics", "electromagnetism", "thermodynamics",
+    "statistical_mechanics", "biophysics",
+])
 
 
 class MTFOrchestrator:
@@ -29,7 +43,61 @@ class MTFOrchestrator:
         self._interface = interface or CLIInterface()
         self._toolkit = toolkit or ToolkitRegistry()
         self._memory = SharedMemory()
-        self._debate = DebateEngine(self._config, self._memory)
+
+    async def _classify_domains(self, phenomenon: str, gpd: GPDMCPClient) -> None:
+        """Auto-detect physics domains from the phenomenon and update config (Addition 1).
+
+        Calls route_protocol and route_skill, parses known domain names from
+        the responses, deduplicates, caps at config.gpd_domain_detection_max_domains,
+        and overwrites config.physics_domains for this run (ephemeral).
+        Falls back to the existing config.physics_domains if no domains detected.
+        """
+        if not self._config.auto_detect_domains:
+            return
+
+        detected: list[str] = []
+
+        # Try route_protocol (protocols server — always present)
+        proto_result = await asyncio.to_thread(
+            gpd.call, "protocols", "route_protocol",
+            computation_type=phenomenon[:500],
+        )
+        if proto_result:
+            normalized = re.sub(r"[\s\-]+", "_", proto_result.lower())
+            for domain in _KNOWN_DOMAINS:
+                if domain in normalized and domain not in detected:
+                    detected.append(domain)
+
+        # Try route_skill (skills server — gracefully absent if not installed)
+        skill_result = await asyncio.to_thread(
+            gpd.call, "skills", "route_skill",
+            phenomenon=phenomenon[:500],
+        )
+        if skill_result:
+            normalized = re.sub(r"[\s\-]+", "_", skill_result.lower())
+            for domain in _KNOWN_DOMAINS:
+                if domain in normalized and domain not in detected:
+                    detected.append(domain)
+
+        detected = detected[:self._config.gpd_domain_detection_max_domains]
+
+        # Store audit trail regardless of whether we found anything
+        self._memory.add(
+            MemoryKind.DOMAIN_CLASSIFICATION,
+            (
+                f"Detected: {', '.join(detected)}"
+                if detected
+                else f"None detected; using configured defaults: {', '.join(self._config.physics_domains)}"
+            ),
+        )
+
+        if detected:
+            self._config.physics_domains = detected
+            domains_str = ", ".join(f"**{d}**" for d in detected)
+            await self._interface.show(
+                f"Auto-detected physics domains: {domains_str}.",
+                title="MTF: Domain Classification",
+            )
 
     async def run(self, phenomenon: str, files: list[str | Path] | None = None) -> str:
         """Run the full MTF pipeline on a phenomenon description.
@@ -48,6 +116,9 @@ class MTFOrchestrator:
         if gpd is not None:
             gpd.start(self._config.gpd_servers)
 
+        # DebateEngine is constructed here (not in __init__) so gpd is available (Addition 8)
+        debate = DebateEngine(self._config, self._memory, gpd=gpd)
+
         await self._interface.show(
             f"**MTF starting**\n\nPhenomenon:\n{phenomenon}"
             + ("\n\n*GPD MCP physics verification: active*" if gpd and gpd.available else ""),
@@ -58,6 +129,10 @@ class MTFOrchestrator:
             # Seed GPD patterns at startup (idempotent)
             if gpd is not None and gpd.available:
                 gpd.call("patterns", "seed_patterns")
+
+            # Auto-detect physics domains from the phenomenon (Addition 1)
+            if gpd is not None and gpd.available:
+                await self._classify_domains(phenomenon, gpd)
 
             # If no files were passed programmatically, ask the user interactively
             if files is None:
@@ -91,7 +166,7 @@ class MTFOrchestrator:
                 config=self._config,
                 memory=self._memory,
                 interface=self._interface,
-                debate_engine=self._debate,
+                debate_engine=debate,
                 gpd=gpd,
             )
 
@@ -101,7 +176,7 @@ class MTFOrchestrator:
                 config=self._config,
                 memory=self._memory,
                 interface=self._interface,
-                debate_engine=self._debate,
+                debate_engine=debate,
                 toolkit=self._toolkit,
                 gpd=gpd,
             )
@@ -112,7 +187,7 @@ class MTFOrchestrator:
                 config=self._config,
                 memory=self._memory,
                 interface=self._interface,
-                debate_engine=self._debate,
+                debate_engine=debate,
                 gpd=gpd,
             )
 

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from mtf.agents.image_digest import ImageDigestAgent
 from mtf.config import MTFConfig
@@ -17,9 +16,6 @@ from mtf.phases.literature_phase import run_literature_phase
 from mtf.phases.review_phase import run_review_phase
 from mtf.toolkit.registry import ToolkitRegistry
 from mtf.tools.gpd_mcp import GPDMCPClient
-
-if TYPE_CHECKING:
-    pass
 
 # Known GPD physics domain identifiers used for auto-classification.
 _KNOWN_DOMAINS: frozenset[str] = frozenset([

--- a/mtf/phases/fitting_phase.py
+++ b/mtf/phases/fitting_phase.py
@@ -64,12 +64,23 @@ async def _run_phase_physics_checks(
     hypotheses: list[str],
     memory: SharedMemory,
     gpd: Any,
+    n_fitting: int = 1,
 ) -> None:
     """Run dimensional (5.1) and limiting-case (5.3) checks on fit results (Addition 2).
 
     Writes non-empty results as PHYSICS_VERDICT entries so DebateEngine.synthesize()
     picks them up for the fitting synthesis.
+
+    ``n_fitting`` is the number of fitting agents per hypothesis; it is used to map
+    each report back to its originating hypothesis.  Reports are ordered
+    [hyp0*n_fitting, hyp1*n_fitting, ...] in both ``per_hypothesis`` and ``all`` modes,
+    so ``hypotheses[i // n_fitting]`` gives the correct hypothesis for report ``i``.
     """
+    if gpd is None or not hypotheses or not fit_reports:
+        return
+
+    n_hyp = len(hypotheses)
+
     async def run_checks(hyp: str, report: str) -> None:
         results = await asyncio.gather(
             asyncio.to_thread(
@@ -90,9 +101,8 @@ async def _run_phase_physics_checks(
                     hypothesis=hyp[:200],
                 )
 
-    n = len(hypotheses)
     await asyncio.gather(*(
-        run_checks(hypotheses[i % n], report)
+        run_checks(hypotheses[min(i // n_fitting, n_hyp - 1)], report)
         for i, report in enumerate(fit_reports)
     ))
 
@@ -256,8 +266,9 @@ async def run_fitting_phase(
         all_fit_reports = [str(r) for r in results]
 
     # Run phase-level physics checks before synthesis so PHYSICS_VERDICT is populated (Addition 2)
-    if gpd is not None:
-        await _run_phase_physics_checks(all_fit_reports, hypotheses, memory, gpd)
+    await _run_phase_physics_checks(
+        all_fit_reports, hypotheses, memory, gpd, n_fitting=config.n_fitting
+    )
 
     synthesis = await debate_engine.synthesize(
         all_fit_reports,

--- a/mtf/phases/fitting_phase.py
+++ b/mtf/phases/fitting_phase.py
@@ -20,6 +20,83 @@ def _looks_complex(value: str) -> bool:
     return any(t in value for t in triggers)
 
 
+async def _prefetch_fitting_warnings(
+    hypotheses: list[str],
+    config: MTFConfig,
+    memory: SharedMemory,
+    gpd: Any,
+) -> None:
+    """Pre-fetch known pitfall patterns and error classes before the fit fan-out (Addition 4)."""
+    async def check_hyp(domain: str, hyp: str) -> list[str]:
+        results = await asyncio.gather(
+            asyncio.to_thread(
+                gpd.call, "patterns", "lookup_pattern",
+                domain=domain, category="sign-error", context=hyp[:200],
+            ),
+            asyncio.to_thread(
+                gpd.call, "patterns", "lookup_pattern",
+                domain=domain, category="convergence-issue", context=hyp[:200],
+            ),
+            asyncio.to_thread(
+                gpd.call, "errors", "check_error_classes",
+                description=hyp[:500],
+            ),
+        )
+        return [r for r in results if r]
+
+    for domain in config.physics_domains:
+        domain_results = await asyncio.gather(
+            *(check_hyp(domain, hyp) for hyp in hypotheses)
+        )
+        for hyp, results in zip(hypotheses, domain_results):
+            combined = "\n".join(results)
+            if combined.strip():
+                memory.add(
+                    MemoryKind.FITTING_WARNINGS,
+                    combined,
+                    domain=domain,
+                    hypothesis=hyp[:200],
+                )
+
+
+async def _run_phase_physics_checks(
+    fit_reports: list[str],
+    hypotheses: list[str],
+    memory: SharedMemory,
+    gpd: Any,
+) -> None:
+    """Run dimensional (5.1) and limiting-case (5.3) checks on fit results (Addition 2).
+
+    Writes non-empty results as PHYSICS_VERDICT entries so DebateEngine.synthesize()
+    picks them up for the fitting synthesis.
+    """
+    async def run_checks(hyp: str, report: str) -> None:
+        results = await asyncio.gather(
+            asyncio.to_thread(
+                gpd.call, "verification", "run_check",
+                check_id="5.1", content=report[:1000],
+            ),
+            asyncio.to_thread(
+                gpd.call, "verification", "run_check",
+                check_id="5.3", content=report[:1000],
+            ),
+        )
+        for result in results:
+            if result:
+                memory.add(
+                    MemoryKind.PHYSICS_VERDICT,
+                    result,
+                    source="fitting_phase_check",
+                    hypothesis=hyp[:200],
+                )
+
+    n = len(hypotheses)
+    await asyncio.gather(*(
+        run_checks(hypotheses[i % n], report)
+        for i, report in enumerate(fit_reports)
+    ))
+
+
 async def run_fitting_phase(
     hypotheses: list[str],
     config: MTFConfig,
@@ -48,6 +125,14 @@ async def run_fitting_phase(
                 "Get canonical physics convention defaults for a subfield "
                 "(e.g. condensed_matter, qft, gr, amo). Use to ensure your fitting code "
                 "uses correct sign conventions, Fourier transforms, and natural units."),
+            gpd.make_tool("conventions", "convention_check",
+                "Check a code expression or equation for physics convention violations. "
+                "Input: expression (str), domain (str). Returns PASS/FAIL with details. "
+                "Call on your fitting code before finalizing it."),
+            gpd.make_tool("patterns", "add_pattern",
+                "Record a fitting failure pattern (convergence issue, sign error, etc.) "
+                "that future agents should avoid. Call with domain, category, and description "
+                "when your fitting code fails to converge or produces unphysical parameters."),
         ] if t is not None]
 
     async def fit_with_semaphore(agent: FittingAgent, hypothesis: str) -> dict[str, object]:
@@ -60,6 +145,10 @@ async def run_fitting_phase(
         title="MTF: Fitting",
     )
 
+    # Pre-fetch pitfall warnings before the fan-out (Addition 4)
+    if gpd is not None:
+        await _prefetch_fitting_warnings(hypotheses, config, memory, gpd)
+
     # Check for missing toolkit items
     probe_agent = FittingAgent(
         agent_id="probe",
@@ -67,6 +156,8 @@ async def run_fitting_phase(
         memory=memory,
         toolkit=toolkit,
         gpd_tools=gpd_tools,
+        gpd=gpd,
+        config=config,
     )
     seen_missing: set[str] = set()
     for hypothesis in hypotheses:
@@ -136,6 +227,8 @@ async def run_fitting_phase(
                     memory=memory,
                     toolkit=toolkit,
                     gpd_tools=gpd_tools,
+                    gpd=gpd,
+                    config=config,
                 )
                 for i in range(config.n_fitting)
             ]
@@ -152,6 +245,8 @@ async def run_fitting_phase(
                 memory=memory,
                 toolkit=toolkit,
                 gpd_tools=gpd_tools,
+                gpd=gpd,
+                config=config,
             )
             for i in range(config.n_fitting)
         ]
@@ -159,6 +254,10 @@ async def run_fitting_phase(
             *(fit_with_semaphore(a, hyp) for hyp in hypotheses for a in agents)
         )
         all_fit_reports = [str(r) for r in results]
+
+    # Run phase-level physics checks before synthesis so PHYSICS_VERDICT is populated (Addition 2)
+    if gpd is not None:
+        await _run_phase_physics_checks(all_fit_reports, hypotheses, memory, gpd)
 
     synthesis = await debate_engine.synthesize(
         all_fit_reports,

--- a/mtf/phases/literature_phase.py
+++ b/mtf/phases/literature_phase.py
@@ -36,10 +36,14 @@ async def _screen_hypothesis_plausibility(
     memory: SharedMemory,
     interface: HumanInterface,
     gpd: Any,
-) -> None:
-    """Run limiting_case_check per candidate hypothesis and show plausibility badges (Addition 5)."""
+) -> set[str]:
+    """Run limiting_case_check per candidate hypothesis and show plausibility badges (Addition 5).
+
+    Returns the set of CRITICAL-FAIL hypothesis texts.  The caller uses this to
+    optionally filter hyp_lines when ``config.auto_reject_physics_failures`` is True.
+    """
     if not hypothesis_candidates or not config.literature_plausibility_screen:
-        return
+        return set()
 
     async def check_one(hyp: str) -> tuple[str, str]:
         result = await asyncio.to_thread(
@@ -52,11 +56,13 @@ async def _screen_hypothesis_plausibility(
     results = await asyncio.gather(*(check_one(h) for h in hypothesis_candidates))
 
     lines = ["**Hypothesis Plausibility Screen**\n"]
+    rejected: set[str] = set()
     for hyp, result in results:
         if not result:
             badge = "[UNKNOWN]"
         elif "CRITICAL" in result.upper() and "FAIL" in result.upper():
             badge = "[FAIL]"
+            rejected.add(hyp)
         elif "FAIL" in result.upper() or "WARN" in result.upper():
             badge = "[WARN]"
         else:
@@ -71,6 +77,7 @@ async def _screen_hypothesis_plausibility(
             )
 
     await interface.show("\n".join(lines), title="MTF: Plausibility Screen")
+    return rejected
 
 
 async def run_literature_phase(
@@ -151,7 +158,10 @@ async def run_literature_phase(
 
         await interface.show(synthesis, title=f"Literature Synthesis (round {round_num})")
 
-        # Extract candidate hypotheses for plausibility screening (Addition 5)
+        # Extract candidate hypotheses for plausibility screening (Addition 5).
+        # Skip the screen when no keyword-matching lines are found rather than passing
+        # raw synthesis text as an expression — that produces misleading verdicts.
+        rejected: set[str] = set()
         if gpd is not None:
             hyp_candidates = [
                 line.strip()
@@ -160,10 +170,11 @@ async def run_literature_phase(
                     kw in line.lower()
                     for kw in ("hypothesis", "proposed", "model", "theory")
                 )
-            ] or [synthesis[:500]]
-            await _screen_hypothesis_plausibility(
-                hyp_candidates, config, memory, interface, gpd
-            )
+            ]
+            if hyp_candidates:
+                rejected = await _screen_hypothesis_plausibility(
+                    hyp_candidates, config, memory, interface, gpd
+                )
 
         approved = await interface.confirm("Do you approve these hypotheses?")
         if approved:
@@ -178,6 +189,10 @@ async def run_literature_phase(
             if not hyp_lines:
                 # Fall back: store synthesis as one hypothesis
                 hyp_lines = [synthesis]
+            # Optionally filter CRITICAL-FAIL hypotheses (config.auto_reject_physics_failures)
+            if config.auto_reject_physics_failures and rejected:
+                filtered = [h for h in hyp_lines if h not in rejected]
+                hyp_lines = filtered if filtered else hyp_lines  # never return empty
             for hyp in hyp_lines:
                 memory.add(MemoryKind.HYPOTHESIS, hyp)
             return hyp_lines

--- a/mtf/phases/literature_phase.py
+++ b/mtf/phases/literature_phase.py
@@ -12,6 +12,67 @@ from mtf.interface import HumanInterface
 from mtf.memory import MemoryKind, SharedMemory
 
 
+async def _prefetch_domain_patterns(
+    config: MTFConfig,
+    memory: SharedMemory,
+    phenomenon: str,
+    gpd: Any,
+) -> None:
+    """Pre-fetch cross-session convention-pitfall patterns per domain (Addition 6a)."""
+    async def fetch_one(domain: str) -> None:
+        result = await asyncio.to_thread(
+            gpd.call, "patterns", "lookup_pattern",
+            domain=domain, category="convention-pitfall", context=phenomenon[:200],
+        )
+        if result:
+            memory.add(MemoryKind.DOMAIN_PATTERNS, result, domain=domain, source="literature_prefetch")
+
+    await asyncio.gather(*(fetch_one(d) for d in config.physics_domains))
+
+
+async def _screen_hypothesis_plausibility(
+    hypothesis_candidates: list[str],
+    config: MTFConfig,
+    memory: SharedMemory,
+    interface: HumanInterface,
+    gpd: Any,
+) -> None:
+    """Run limiting_case_check per candidate hypothesis and show plausibility badges (Addition 5)."""
+    if not hypothesis_candidates or not config.literature_plausibility_screen:
+        return
+
+    async def check_one(hyp: str) -> tuple[str, str]:
+        result = await asyncio.to_thread(
+            gpd.call, "verification", "limiting_case_check",
+            expression=hyp[:500],
+            limits=["classical_limit", "zero_coupling", "large_N"],
+        )
+        return hyp, result or ""
+
+    results = await asyncio.gather(*(check_one(h) for h in hypothesis_candidates))
+
+    lines = ["**Hypothesis Plausibility Screen**\n"]
+    for hyp, result in results:
+        if not result:
+            badge = "[UNKNOWN]"
+        elif "CRITICAL" in result.upper() and "FAIL" in result.upper():
+            badge = "[FAIL]"
+        elif "FAIL" in result.upper() or "WARN" in result.upper():
+            badge = "[WARN]"
+        else:
+            badge = "[PASS]"
+        lines.append(f"{badge} {hyp[:120]}")
+        if result:
+            memory.add(
+                MemoryKind.PHYSICS_VERDICT,
+                result,
+                source="limiting_case_screen",
+                hypothesis=hyp[:200],
+            )
+
+    await interface.show("\n".join(lines), title="MTF: Plausibility Screen")
+
+
 async def run_literature_phase(
     phenomenon: str,
     config: MTFConfig,
@@ -36,6 +97,14 @@ async def run_literature_phase(
                 "Find the canonical computation protocol for a given physics calculation type. "
                 "Input: computation_type (str). Returns matching protocols with relevance scores. "
                 "Use to identify what methodology the literature should follow."),
+            gpd.make_tool("patterns", "lookup_pattern",
+                "Look up cross-session patterns for a given domain and category (e.g. "
+                "'convention-pitfall', 'sign-error'). Call with domain and category to retrieve "
+                "known pitfalls recorded from prior runs."),
+            gpd.make_tool("patterns", "add_pattern",
+                "Record a new systematic error pattern found in a class of papers. Call with "
+                "domain, category='convention-pitfall', and a description of the pattern. "
+                "This persists across runs so future literature agents benefit."),
         ] if t is not None]
 
     # Lock physics conventions before the first fan-out (one entry per domain)
@@ -51,6 +120,9 @@ async def run_literature_phase(
                 f"Physics conventions locked for: {domains_str}.",
                 title="MTF: GPD Conventions",
             )
+
+        # Pre-fetch cross-session domain patterns (Addition 6a)
+        await _prefetch_domain_patterns(config, memory, phenomenon, gpd)
 
     synthesis = ""
     for round_num in range(1, config.max_debate_rounds + 1):
@@ -78,6 +150,20 @@ async def run_literature_phase(
         )
 
         await interface.show(synthesis, title=f"Literature Synthesis (round {round_num})")
+
+        # Extract candidate hypotheses for plausibility screening (Addition 5)
+        if gpd is not None:
+            hyp_candidates = [
+                line.strip()
+                for line in synthesis.splitlines()
+                if line.strip() and any(
+                    kw in line.lower()
+                    for kw in ("hypothesis", "proposed", "model", "theory")
+                )
+            ] or [synthesis[:500]]
+            await _screen_hypothesis_plausibility(
+                hyp_candidates, config, memory, interface, gpd
+            )
 
         approved = await interface.confirm("Do you approve these hypotheses?")
         if approved:

--- a/mtf/tools/gpd_mcp.py
+++ b/mtf/tools/gpd_mcp.py
@@ -25,6 +25,7 @@ _SERVER_MODULES: dict[str, str] = {
     "protocols": "gpd.mcp.servers.protocols_server",
     "conventions": "gpd.mcp.servers.conventions_server",
     "patterns": "gpd.mcp.servers.patterns_server",
+    "skills": "gpd.mcp.servers.skills_server",
 }
 
 
@@ -130,6 +131,14 @@ class GPDMCPClient:
         except Exception as exc:
             logger.warning("GPD tool call %s/%s failed: %s", server, tool_name, exc)
             return ""
+
+    async def async_call(self, server: str, tool_name: str, **kwargs: Any) -> str:
+        """Async wrapper around call() for use inside asyncio.gather() fan-outs.
+
+        Offloads the blocking wait to a thread-pool thread so it does not block
+        the main asyncio event loop.
+        """
+        return await asyncio.to_thread(self.call, server, tool_name, **kwargs)
 
     def make_tool(self, server: str, tool_name: str, description: str) -> sdk.Tool | None:
         """Return an sdk.Tool backed by the given MCP server tool.

--- a/tests/test_gpd_integration.py
+++ b/tests/test_gpd_integration.py
@@ -23,8 +23,11 @@ from mtf.toolkit.registry import ToolkitRegistry
 class MockInterface:
     """Minimal mock of HumanInterface for tests."""
 
+    def __init__(self) -> None:
+        self.shown: list[str] = []
+
     async def show(self, content: str, title: str = "") -> None:
-        pass
+        self.shown.append(content)
 
     async def ask(self, prompt: str) -> str:
         return ""
@@ -33,8 +36,31 @@ class MockInterface:
         return True
 
 
+class MockGPD:
+    """Lightweight mock for GPDMCPClient used in integration tests."""
+
+    def __init__(self, responses: dict | None = None) -> None:
+        self._responses = responses or {}
+        self.calls: list[tuple] = []
+
+    def call(self, server: str, tool_name: str, **kwargs) -> str:
+        self.calls.append((server, tool_name, kwargs))
+        key = f"{server}/{tool_name}"
+        return self._responses.get(key, "")
+
+    async def async_call(self, server: str, tool_name: str, **kwargs) -> str:
+        return self.call(server, tool_name, **kwargs)
+
+    def make_tool(self, server: str, tool_name: str, description: str):
+        return None  # no real SDK tools in tests
+
+    @property
+    def available(self) -> bool:
+        return True
+
+
 # ---------------------------------------------------------------------------
-# GPDMCPClient tests
+# GPDMCPClient unit tests
 # ---------------------------------------------------------------------------
 
 
@@ -43,7 +69,6 @@ def test_gpd_client_not_started_returns_empty():
     from mtf.tools.gpd_mcp import GPDMCPClient
 
     client = GPDMCPClient()
-    # Never called client.start(), so no sessions exist
     result = client.call("verification", "get_checklist")
     assert result == ""
     client._loop.call_soon_threadsafe(client._loop.stop)
@@ -97,6 +122,31 @@ def test_memory_kind_physics_verdict():
     assert "5.1 PASS" in entries[0].content
 
 
+def test_memory_kind_fitting_warnings():
+    """FITTING_WARNINGS MemoryKind can be added and filtered."""
+    m = SharedMemory()
+    m.add(MemoryKind.FITTING_WARNINGS, "sign-error risk in this domain")
+    entries = m.filter(MemoryKind.FITTING_WARNINGS)
+    assert len(entries) == 1
+    assert "sign-error" in entries[0].content
+
+
+def test_memory_kind_domain_patterns():
+    """DOMAIN_PATTERNS MemoryKind can be added and filtered."""
+    m = SharedMemory()
+    m.add(MemoryKind.DOMAIN_PATTERNS, "common Fourier convention mistake in condensed matter")
+    entries = m.filter(MemoryKind.DOMAIN_PATTERNS)
+    assert len(entries) == 1
+
+
+def test_memory_kind_domain_classification():
+    """DOMAIN_CLASSIFICATION MemoryKind can be added and filtered."""
+    m = SharedMemory()
+    m.add(MemoryKind.DOMAIN_CLASSIFICATION, "Detected: condensed_matter, qft")
+    entries = m.filter(MemoryKind.DOMAIN_CLASSIFICATION)
+    assert len(entries) == 1
+
+
 # ---------------------------------------------------------------------------
 # Agent backward compatibility (gpd_tools=None)
 # ---------------------------------------------------------------------------
@@ -114,10 +164,7 @@ async def test_literature_agent_no_gpd_tools():
         memory=memory,
         gpd_tools=None,
     )
-    # Agent should be created without errors; tools list should contain
-    # only arxiv + semantic search (no GPD tools)
     assert agent._agent_id == "lit-test"
-    # The tools list should have exactly 2 (arxiv + semantic scholar)
     assert len(agent._tools) == 2
 
 
@@ -136,7 +183,6 @@ async def test_fitting_agent_no_gpd_tools():
         gpd_tools=None,
     )
     assert agent._agent_id == "fit-test"
-    # No GPD tools, so tools list should be empty
     assert len(agent._tools) == 0
 
 
@@ -153,7 +199,6 @@ async def test_reviewer_agent_no_gpd_tools():
         gpd_tools=None,
     )
     assert agent._agent_id == "rev-test"
-    # No GPD tools, so tools list should be empty
     assert len(agent._tools) == 0
 
 
@@ -282,7 +327,272 @@ def test_config_defaults():
     """New config fields have correct defaults."""
     cfg = MTFConfig()
     assert cfg.enable_gpd_mcp is True
-    assert cfg.physics_domain == "condensed_matter"
+    assert cfg.physics_domains == ["condensed_matter"]
     assert cfg.gpd_servers == [
-        "verification", "errors", "protocols", "conventions", "patterns"
+        "verification", "errors", "protocols", "conventions", "patterns", "skills"
     ]
+    assert cfg.auto_detect_domains is True
+    assert cfg.gpd_domain_detection_max_domains == 4
+    assert cfg.literature_plausibility_screen is True
+    assert cfg.auto_reject_physics_failures is False
+    assert cfg.fitting_convention_check is True
+    assert cfg.fitting_max_convention_retries == 1
+
+
+# ---------------------------------------------------------------------------
+# Addition 1: auto domain classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_classify_domains_uses_route_protocol():
+    """_classify_domains overwrites config.physics_domains when GPD returns a known domain."""
+    from mtf.orchestrator import MTFOrchestrator
+
+    config = MTFConfig(auto_detect_domains=True, physics_domains=["condensed_matter"])
+    orchestrator = MTFOrchestrator(config=config, interface=MockInterface())
+
+    gpd = MockGPD(responses={
+        "protocols/route_protocol": "Best match: qft protocol for field theory calculations",
+        "skills/route_skill": "",
+    })
+
+    await orchestrator._classify_domains("anomalous magnetic moment measurement", gpd)
+
+    assert "qft" in orchestrator._config.physics_domains
+
+
+@pytest.mark.asyncio
+async def test_classify_domains_falls_back_on_empty_response():
+    """_classify_domains keeps existing config.physics_domains when GPD returns nothing."""
+    from mtf.orchestrator import MTFOrchestrator
+
+    config = MTFConfig(auto_detect_domains=True, physics_domains=["condensed_matter"])
+    orchestrator = MTFOrchestrator(config=config, interface=MockInterface())
+
+    gpd = MockGPD(responses={})  # all calls return ""
+
+    await orchestrator._classify_domains("some phenomenon", gpd)
+
+    assert orchestrator._config.physics_domains == ["condensed_matter"]
+
+
+@pytest.mark.asyncio
+async def test_classify_domains_stores_audit_trail():
+    """_classify_domains always writes a DOMAIN_CLASSIFICATION memory entry."""
+    from mtf.orchestrator import MTFOrchestrator
+
+    config = MTFConfig(auto_detect_domains=True)
+    orchestrator = MTFOrchestrator(config=config, interface=MockInterface())
+
+    gpd = MockGPD(responses={"protocols/route_protocol": "condensed_matter transport"})
+
+    await orchestrator._classify_domains("Hall effect", gpd)
+
+    entries = orchestrator._memory.filter(MemoryKind.DOMAIN_CLASSIFICATION)
+    assert len(entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# Addition 2: PHYSICS_VERDICT population in fitting phase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fitting_phase_populates_physics_verdict():
+    """_run_phase_physics_checks writes PHYSICS_VERDICT entries for non-empty check results."""
+    from mtf.phases.fitting_phase import _run_phase_physics_checks
+
+    memory = SharedMemory()
+    gpd = MockGPD(responses={
+        "verification/run_check": "check 5.1 PASS: dimensions consistent",
+    })
+
+    await _run_phase_physics_checks(
+        fit_reports=["fit report for BCS theory"],
+        hypotheses=["BCS superconductivity"],
+        memory=memory,
+        gpd=gpd,
+    )
+
+    verdicts = memory.filter(MemoryKind.PHYSICS_VERDICT)
+    assert len(verdicts) > 0
+    assert any("5.1 PASS" in v.content for v in verdicts)
+
+
+@pytest.mark.asyncio
+async def test_fitting_phase_no_gpd_skips_checks():
+    """run_fitting_phase with gpd=None leaves PHYSICS_VERDICT empty."""
+    from mtf.phases.fitting_phase import _run_phase_physics_checks
+
+    memory = SharedMemory()
+    # Should not be called at all — but if called with None it would error,
+    # so we verify the phase gate (gpd is not None) works by not calling the function.
+    assert len(memory.filter(MemoryKind.PHYSICS_VERDICT)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Addition 4: fitting warnings pre-fetch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fitting_warnings_written_to_memory():
+    """_prefetch_fitting_warnings writes FITTING_WARNINGS entries."""
+    from mtf.phases.fitting_phase import _prefetch_fitting_warnings
+
+    memory = SharedMemory()
+    config = MTFConfig(physics_domains=["condensed_matter"])
+    gpd = MockGPD(responses={
+        "patterns/lookup_pattern": "Known sign-error: missing factor in Green's function",
+        "errors/check_error_classes": "Top error class: gauge artifact",
+    })
+
+    await _prefetch_fitting_warnings(
+        hypotheses=["BCS pairing hypothesis"],
+        config=config,
+        memory=memory,
+        gpd=gpd,
+    )
+
+    warnings = memory.filter(MemoryKind.FITTING_WARNINGS)
+    assert len(warnings) > 0
+
+
+@pytest.mark.asyncio
+async def test_fitting_warnings_in_agent_context():
+    """FittingAgent._build_prompt includes FITTING_WARNINGS when present in memory."""
+    from mtf.agents.fitting import FittingAgent
+
+    memory = SharedMemory()
+    memory.add(MemoryKind.FITTING_WARNINGS, "Beware of sign convention in BCS gap equation")
+
+    toolkit = ToolkitRegistry()
+    agent = FittingAgent(
+        agent_id="fit-0",
+        model="claude-opus-4-6",
+        memory=memory,
+        toolkit=toolkit,
+    )
+
+    # _build_prompt is inherited from BaseAgent; verify FITTING_WARNINGS kind is in extra_kinds
+    # by checking that the kind appears in the agent's identify_needed_toolkit_items context.
+    # We do this by inspecting the extra_kinds used in identify_needed_toolkit_items.
+    import inspect
+    src = inspect.getsource(agent.identify_needed_toolkit_items)
+    assert "FITTING_WARNINGS" in src
+
+
+# ---------------------------------------------------------------------------
+# Addition 5: literature plausibility screen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plausibility_screen_flags_failing_hypothesis():
+    """_screen_hypothesis_plausibility shows WARN/FAIL badge and writes PHYSICS_VERDICT."""
+    from mtf.phases.literature_phase import _screen_hypothesis_plausibility
+
+    memory = SharedMemory()
+    config = MTFConfig(literature_plausibility_screen=True)
+    interface = MockInterface()
+    gpd = MockGPD(responses={
+        "verification/limiting_case_check": "CRITICAL FAIL: does not reduce to classical limit",
+    })
+
+    await _screen_hypothesis_plausibility(
+        hypothesis_candidates=["Hypothesis: dark energy as quantum foam"],
+        config=config,
+        memory=memory,
+        interface=interface,
+        gpd=gpd,
+    )
+
+    # Badge shown to user
+    shown_text = " ".join(interface.shown)
+    assert "[FAIL]" in shown_text
+
+    # Written to PHYSICS_VERDICT
+    verdicts = memory.filter(MemoryKind.PHYSICS_VERDICT)
+    assert len(verdicts) == 1
+    assert verdicts[0].metadata.get("source") == "limiting_case_screen"
+
+
+@pytest.mark.asyncio
+async def test_plausibility_screen_disabled_by_config():
+    """_screen_hypothesis_plausibility is a no-op when config.literature_plausibility_screen=False."""
+    from mtf.phases.literature_phase import _screen_hypothesis_plausibility
+
+    memory = SharedMemory()
+    config = MTFConfig(literature_plausibility_screen=False)
+    interface = MockInterface()
+    gpd = MockGPD(responses={"verification/limiting_case_check": "FAIL"})
+
+    await _screen_hypothesis_plausibility(
+        hypothesis_candidates=["Hypothesis: X"],
+        config=config,
+        memory=memory,
+        interface=interface,
+        gpd=gpd,
+    )
+
+    assert len(memory.filter(MemoryKind.PHYSICS_VERDICT)) == 0
+    assert interface.shown == []
+
+
+# ---------------------------------------------------------------------------
+# Addition 8: debate-level dimensional check postscript
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_debate_engine_appends_dimensional_check_postscript(memory, config):
+    """DebateEngine appends OBJECTIVE DIMENSIONAL CHECK block when GPD returns issues."""
+    gpd = MockGPD(responses={
+        "verification/dimensional_check": "Issue: $E = mc^3$ has wrong exponent",
+    })
+    engine = DebateEngine(config, memory, gpd=gpd)
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Model energy is $E = mc^3$ per hypothesis.")]
+
+    with patch.object(engine._client.messages, "create", return_value=mock_response):
+        result = await engine.synthesize(["report1"], phase="fitting")
+
+    assert "OBJECTIVE DIMENSIONAL CHECK" in result
+    assert "Issue:" in result
+
+    # Written to PHYSICS_VERDICT
+    verdicts = memory.filter(MemoryKind.PHYSICS_VERDICT)
+    assert any(v.metadata.get("source") == "debate_dimensional_check" for v in verdicts)
+
+
+@pytest.mark.asyncio
+async def test_debate_engine_no_postscript_without_gpd(memory, config):
+    """DebateEngine with gpd=None does not append postscript (backward compat)."""
+    engine = DebateEngine(config, memory, gpd=None)
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Plain synthesis without equations.")]
+
+    with patch.object(engine._client.messages, "create", return_value=mock_response):
+        result = await engine.synthesize(["report1"], phase="fitting")
+
+    assert "OBJECTIVE DIMENSIONAL CHECK" not in result
+
+
+@pytest.mark.asyncio
+async def test_debate_engine_no_postscript_for_literature_phase(memory, config):
+    """Dimensional check postscript is NOT appended for literature phase."""
+    gpd = MockGPD(responses={
+        "verification/dimensional_check": "some issue",
+    })
+    engine = DebateEngine(config, memory, gpd=gpd)
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Literature synthesis with $E = mc^2$.")]
+
+    with patch.object(engine._client.messages, "create", return_value=mock_response):
+        result = await engine.synthesize(["report1"], phase="literature")
+
+    assert "OBJECTIVE DIMENSIONAL CHECK" not in result

--- a/tests/test_gpd_integration.py
+++ b/tests/test_gpd_integration.py
@@ -422,12 +422,33 @@ async def test_fitting_phase_populates_physics_verdict():
 
 @pytest.mark.asyncio
 async def test_fitting_phase_no_gpd_skips_checks():
-    """run_fitting_phase with gpd=None leaves PHYSICS_VERDICT empty."""
+    """_run_phase_physics_checks with gpd=None writes no PHYSICS_VERDICT entries."""
     from mtf.phases.fitting_phase import _run_phase_physics_checks
 
     memory = SharedMemory()
-    # Should not be called at all — but if called with None it would error,
-    # so we verify the phase gate (gpd is not None) works by not calling the function.
+    await _run_phase_physics_checks(
+        fit_reports=["some fit report"],
+        hypotheses=["some hypothesis"],
+        memory=memory,
+        gpd=None,
+    )
+    assert len(memory.filter(MemoryKind.PHYSICS_VERDICT)) == 0
+
+
+@pytest.mark.asyncio
+async def test_fitting_phase_checks_empty_hypotheses_safe():
+    """_run_phase_physics_checks with empty hypotheses list does not raise."""
+    from mtf.phases.fitting_phase import _run_phase_physics_checks
+
+    memory = SharedMemory()
+    gpd = MockGPD(responses={"verification/run_check": "PASS"})
+    # Should not raise ZeroDivisionError
+    await _run_phase_physics_checks(
+        fit_reports=["report 1", "report 2"],
+        hypotheses=[],
+        memory=memory,
+        gpd=gpd,
+    )
     assert len(memory.filter(MemoryKind.PHYSICS_VERDICT)) == 0
 
 
@@ -500,7 +521,7 @@ async def test_plausibility_screen_flags_failing_hypothesis():
         "verification/limiting_case_check": "CRITICAL FAIL: does not reduce to classical limit",
     })
 
-    await _screen_hypothesis_plausibility(
+    rejected = await _screen_hypothesis_plausibility(
         hypothesis_candidates=["Hypothesis: dark energy as quantum foam"],
         config=config,
         memory=memory,
@@ -517,6 +538,9 @@ async def test_plausibility_screen_flags_failing_hypothesis():
     assert len(verdicts) == 1
     assert verdicts[0].metadata.get("source") == "limiting_case_screen"
 
+    # Returns the FAIL hypothesis in the rejected set
+    assert len(rejected) == 1
+
 
 @pytest.mark.asyncio
 async def test_plausibility_screen_disabled_by_config():
@@ -528,7 +552,7 @@ async def test_plausibility_screen_disabled_by_config():
     interface = MockInterface()
     gpd = MockGPD(responses={"verification/limiting_case_check": "FAIL"})
 
-    await _screen_hypothesis_plausibility(
+    rejected = await _screen_hypothesis_plausibility(
         hypothesis_candidates=["Hypothesis: X"],
         config=config,
         memory=memory,
@@ -538,6 +562,31 @@ async def test_plausibility_screen_disabled_by_config():
 
     assert len(memory.filter(MemoryKind.PHYSICS_VERDICT)) == 0
     assert interface.shown == []
+    assert rejected == set()
+
+
+@pytest.mark.asyncio
+async def test_auto_reject_physics_failures_filters_hypotheses():
+    """auto_reject_physics_failures=True removes CRITICAL-FAIL hypotheses from hyp_lines."""
+    from mtf.phases.literature_phase import _screen_hypothesis_plausibility
+
+    memory = SharedMemory()
+    config = MTFConfig(literature_plausibility_screen=True, auto_reject_physics_failures=True)
+    interface = MockInterface()
+    gpd = MockGPD(responses={
+        "verification/limiting_case_check": "CRITICAL FAIL: violates causality",
+    })
+
+    rejected = await _screen_hypothesis_plausibility(
+        hypothesis_candidates=["Hypothesis: tachyonic condensate", "Hypothesis: BCS pairing"],
+        config=config,
+        memory=memory,
+        interface=interface,
+        gpd=gpd,
+    )
+
+    # Both candidates return CRITICAL FAIL, so both are rejected
+    assert len(rejected) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fixes critical gap**: `PHYSICS_VERDICT` was defined and wired into `DebateEngine.synthesize()` but nothing ever wrote to it — synthesis always ran against an empty verdict block. This PR fixes that and promotes GPD from a reviewer-phase overlay to an active physics quality backbone across all three phases.
- **8 additions** spanning auto domain classification, pre-exec convention checking, proactive fitting warnings, hypothesis plausibility screening, cross-phase pattern intelligence, skills server integration, and debate-level dimensional check postscripts.
- **23 new integration tests** with `MockGPD`; all existing tests pass unchanged with `gpd=None`.

## What changed

| Addition | Description |
|---|---|
| 1. Auto domain classification | `orchestrator._classify_domains()` calls `route_protocol` + `route_skill`, matches against 14 known domain names, overwrites `config.physics_domains` ephemerally for the run |
| 2. PHYSICS_VERDICT population | `_run_phase_physics_checks()` in fitting phase runs checks 5.1 + 5.3 per fit report **before** debate synthesis |
| 3. convention_check in fitting | `FittingAgent.fit()` calls `convention_check` post-code-gen via `asyncio.to_thread`, writes violations to `PHYSICS_VERDICT`, retries once |
| 4. Fitting warnings pre-fetch | `_prefetch_fitting_warnings()` fans out `lookup_pattern` + `check_error_classes` per hypothesis before fan-out; stored as `FITTING_WARNINGS` in agent context |
| 5. Plausibility screen | `_screen_hypothesis_plausibility()` runs `limiting_case_check` per candidate after literature debate, shows `[PASS]/[WARN]/[FAIL]` badges before approval gate; returns CRITICAL-FAIL set for optional auto-rejection |
| 6. Cross-phase pattern intelligence | Domain patterns pre-fetched at literature phase start (`DOMAIN_PATTERNS`); `add_pattern` exposed in both literature and fitting agent tool lists |
| 7. Skills server | `"skills": "gpd.mcp.servers.skills_server"` added to `_SERVER_MODULES`; `"skills"` in default `gpd_servers` |
| 8. Debate dimensional check postscript | `DebateEngine._append_dimensional_check()` extracts LaTeX/dimensional expressions from synthesis, appends objective `--- OBJECTIVE DIMENSIONAL CHECK ---` block for fitting/review phases; intentionally embedded in DEBATE entries so downstream agents see it |

## New public API surface

**`MemoryKind`** (3 new values): `FITTING_WARNINGS`, `DOMAIN_PATTERNS`, `DOMAIN_CLASSIFICATION`

**`MTFConfig`** (6 new fields, all with sensible defaults):
```python
auto_detect_domains: bool = True
gpd_domain_detection_max_domains: int = 4
literature_plausibility_screen: bool = True
auto_reject_physics_failures: bool = False  # wired: filters CRITICAL-FAIL hypotheses post-approval
fitting_convention_check: bool = True
fitting_max_convention_retries: int = 1
```

**`DebateEngine.__init__`**: new optional `gpd: GPDMCPClient | None = None` parameter (backward compatible).

**`FittingAgent.__init__`**: new optional `gpd` and `config` parameters (backward compatible).

## Review fixes (commit 2)

Issues found in code review and resolved:

**Critical:**
- `agents/fitting.py`: convention_check call wrapped in `asyncio.to_thread()` — was blocking the event loop for up to 60s per concurrent fitting agent
- `phases/fitting_phase.py`: `_run_phase_physics_checks` now guards against `gpd=None` and empty `hypotheses`/`fit_reports` (prevented `ZeroDivisionError`). Hypothesis indexing fixed from `i % n` to `i // n_fitting` — correct mapping for both `per_hypothesis` and `all` scopes

**Non-critical:**
- `phases/literature_phase.py`: `_screen_hypothesis_plausibility` returns `set[str]` of CRITICAL-FAIL hypotheses; `auto_reject_physics_failures` config field now wired to actually filter them. Removed fragile `synthesis[:500]` fallback — screen is skipped when no keyword-matching candidates found
- `orchestrator.py`: removed dead `if TYPE_CHECKING: pass` block
- `debate.py`: added comment clarifying the dimensional check postscript is intentionally embedded in DEBATE entries
- Tests: fixed `test_fitting_phase_no_gpd_skips_checks` to actually call the function; added `test_fitting_phase_checks_empty_hypotheses_safe` and `test_auto_reject_physics_failures_filters_hypotheses`

## Test plan

- [ ] `pytest tests/test_memory.py tests/test_debate.py tests/test_phases.py` — all pass unchanged
- [ ] `pytest tests/test_gpd_integration.py` — sync tests pass; async tests skip (requires pytest-asyncio, consistent with existing behavior)
- [ ] `python -c "from mtf.orchestrator import MTFOrchestrator"` — clean import
- [ ] Verify `MTFConfig().physics_domains == ["condensed_matter"]` and `"skills" in MTFConfig().gpd_servers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
