### PR TITLE
Optional fitting phase with qualitative evaluation fallback

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -197,6 +197,29 @@ The fit output and hypothesis text are stored as `FIT_RESULT`.
 
 ---
 
+## QualitativeEvaluationAgent
+
+| | |
+|---|---|
+| **Phase** | ② Qualitative Evaluation (when `--no-fitting` is used) |
+| **API** | `sdk.query()` (agentic) |
+| **Tools** | GPD: `get_checklist`, `run_check`, `dimensional_check`, `limiting_case_check`, `check_error_classes`, `get_detection_strategy`, `lookup_pattern`, `add_pattern` |
+| **Memory context read** | `IMAGE_DATA`, `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS` |
+| **Memory written** | `QUALITATIVE_EVAL` |
+
+Used instead of `FittingAgent` when the pipeline runs with `--no-fitting`. N instances run
+concurrently. Each evaluates all hypotheses against established theory, literature context,
+and image-extracted data — without numerical fitting. For each hypothesis, the agent produces:
+a theoretical plausibility assessment, expected observational signatures, the specific data
+that would be needed to upgrade the assessment to a quantitative fit, a verdict
+(SUPPORTED / PLAUSIBLE / SPECULATIVE / REJECTED), and the single most decisive measurement
+that would confirm or refute it. Results are synthesized via
+`DebateEngine.synthesize(phase="qualitative")` and stored as `QUALITATIVE_EVAL`. The
+`ReviewerAgent` reads `QUALITATIVE_EVAL` in its `extra_kinds` so the review phase adapts its
+tone accordingly.
+
+---
+
 ## ReviewerAgent
 
 | | |
@@ -204,7 +227,7 @@ The fit output and hypothesis text are stored as `FIT_RESULT`.
 | **Phase** | ③ Review |
 | **API** | `sdk.query()` (agentic) |
 | **Tools** | GPD: `get_checklist`, `run_check`, `dimensional_check`, `limiting_case_check`, `check_error_classes`, `get_detection_strategy`, `lookup_pattern`, `add_pattern` |
-| **Memory context read** | `LITERATURE`, `DEBATE`, `FIT_RESULT`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT` |
+| **Memory context read** | `LITERATURE`, `DEBATE`, `FIT_RESULT`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT`, `QUALITATIVE_EVAL`, `FITTING_SKIPPED` |
 | **Memory written** | `REVIEW` |
 
 K instances run concurrently.  `ReviewerAgent` reads the widest memory context of any

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -204,7 +204,7 @@ The fit output and hypothesis text are stored as `FIT_RESULT`.
 | **Phase** | ② Qualitative Evaluation (when `--no-fitting` is used) |
 | **API** | `sdk.query()` (agentic) |
 | **Tools** | GPD: `get_checklist`, `run_check`, `dimensional_check`, `limiting_case_check`, `check_error_classes`, `get_detection_strategy`, `lookup_pattern`, `add_pattern` |
-| **Memory context read** | `IMAGE_DATA`, `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS` |
+| **Memory context read** | `IMAGE_DATA`, `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `CONVENTIONS`, `PHYSICS_VERDICT` |
 | **Memory written** | `QUALITATIVE_EVAL` |
 
 Used instead of `FittingAgent` when the pipeline runs with `--no-fitting`. N instances run

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -38,6 +38,8 @@ class MemoryEntry:
 | `DOMAIN_PATTERNS` | Literature phase (GPD) | Cross-session convention-pitfall patterns pre-fetched before the first literature fan-out via `lookup_pattern(category="convention-pitfall")`.  Carries `domain` and `source` metadata. |
 | `DOMAIN_CLASSIFICATION` | `MTFOrchestrator._classify_domains()` | Audit trail of auto-detected physics domains when `config.auto_detect_domains=True`.  Records either the detected list or a fallback notice.  Informational only — not consumed by agents via `extra_kinds`. |
 | `TOOLKIT_DIGEST` | `ToolBuilderAgent` | Summary of data and model items parsed from complex user-supplied input by the tool-builder agent. |
+| `QUALITATIVE_EVAL` | `QualitativeEvaluationAgent` | Qualitative hypothesis evaluation report produced when `--no-fitting` is used. Contains per-hypothesis SUPPORTED/PLAUSIBLE/SPECULATIVE/REJECTED verdicts based on theory and image data, without numerical fitting. Read by `ReviewerAgent`. |
+| `FITTING_SKIPPED` | Qualitative phase | Flag entry written when the fitting phase is skipped. Content: `"Fitting phase was skipped (--no-fitting). Qualitative evaluation substituted."` Read by `ReviewerAgent` for context. |
 
 ---
 
@@ -76,7 +78,8 @@ Task: Investigate the following experimental phenomenon …
 | `LiteratureAgent.investigate()` | `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `DOMAIN_PATTERNS` |
 | `FittingAgent.identify_needed_toolkit_items()` | `LITERATURE`, `DEBATE`, `IMAGE_DATA`, `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS` |
 | `FittingAgent.fit()` | `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS` |
-| `ReviewerAgent.review()` | `LITERATURE`, `DEBATE`, `FIT_RESULT`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT` |
+| `QualitativeEvaluationAgent.evaluate()` | `IMAGE_DATA`, `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS` |
+| `ReviewerAgent.review()` | `LITERATURE`, `DEBATE`, `FIT_RESULT`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT`, `QUALITATIVE_EVAL`, `FITTING_SKIPPED` |
 
 `DebateEngine.synthesize()` always calls `memory.format_context()` with no arguments,
 receiving all entries regardless of kind, plus it explicitly appends `CONVENTIONS` and
@@ -102,8 +105,13 @@ Entries accumulate in chronological order within a single pipeline run:
 [USER_FEEDBACK]    0 or more, one per rejection         (phase 1)
 [DEBATE]           one per round (phase="literature")   (phase 1)
 [HYPOTHESIS]       one per approved hypothesis line     (phase 1 approval)
+# Fitting path (default):
 [FIT_RESULT]       M × N_hypotheses entries             (phase 2)
 [DEBATE]           one (phase="fitting")                (phase 2)
+# Qualitative path (--no-fitting):
+[QUALITATIVE_EVAL] N entries, one per eval agent        (phase 2)
+[FITTING_SKIPPED]  one flag entry                       (phase 2)
+[DEBATE]           one (phase="qualitative")            (phase 2)
 [REVIEW]           K entries, one per reviewer          (phase 3)
 [PHYSICS_VERDICT]  0 or more                            (phase 3)
 [DEBATE]           one (phase="review")                 (phase 3)

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -78,7 +78,7 @@ Task: Investigate the following experimental phenomenon …
 | `LiteratureAgent.investigate()` | `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `DOMAIN_PATTERNS` |
 | `FittingAgent.identify_needed_toolkit_items()` | `LITERATURE`, `DEBATE`, `IMAGE_DATA`, `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS` |
 | `FittingAgent.fit()` | `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `FITTING_WARNINGS`, `DOMAIN_PATTERNS` |
-| `QualitativeEvaluationAgent.evaluate()` | `IMAGE_DATA`, `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS` |
+| `QualitativeEvaluationAgent.evaluate()` | `IMAGE_DATA`, `LITERATURE`, `DEBATE`, `USER_FEEDBACK`, `CONVENTIONS`, `PHYSICS_VERDICT` |
 | `ReviewerAgent.review()` | `LITERATURE`, `DEBATE`, `FIT_RESULT`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT`, `QUALITATIVE_EVAL`, `FITTING_SKIPPED` |
 
 `DebateEngine.synthesize()` always calls `memory.format_context()` with no arguments,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -31,15 +31,22 @@ flowchart TD
         LU -->|"reject: add feedback"| L
     end
 
-    subgraph FIT ["② FITTING PHASE  —  per approved hypothesis"]
+    subgraph FIT ["② FITTING / QUALITATIVE EVALUATION PHASE"]
         direction TB
-        FW["Pre-fetch FITTING_WARNINGS\nlookup_pattern + check_error_classes per hypothesis"]
-        FT["toolkit check\n(request missing data from user)"]
-        F["F1 · F2 · F3\nM parallel agents\nlmfit + numpy/scipy\n+ GPD: route_protocol, get_protocol,\nsubfield_defaults, convention_check, add_pattern"]
-        FC["Phase physics checks\nrun_check 5.1 + 5.3 per fit result → PHYSICS_VERDICT"]
-        FD["🔀 Debate\nphysics-first ranking + dimensional check postscript"]
+        FitChoice{"--no-fitting?"}
+        FW["Pre-fetch FITTING_WARNINGS"]
+        FT["toolkit check"]
+        F["F1 · F2 · F3\nM parallel fitting agents\nlmfit + numpy/scipy + GPD tools"]
+        FC["Phase physics checks → PHYSICS_VERDICT"]
+        FD["🔀 Debate (fitting)"]
         FU{"User approval"}
+        QE["Q1 · Q2 · Q3\nN parallel qualitative eval agents\n+ same GPD tools as ReviewerAgent"]
+        QD["🔀 Debate (qualitative)"]
+        QU{"User approval"}
+        FitChoice -->|"fitting enabled (default)"| FW
         FW --> FT --> F --> FC --> FD --> FU
+        FitChoice -->|"--no-fitting"| QE
+        QE --> QD --> QU
     end
 
     subgraph REV ["③ REVIEW PHASE"]
@@ -252,6 +259,28 @@ dimensional check postscript (stored as both part of `DEBATE` and as `PHYSICS_VE
 The fitting synthesis is shown to the user.  If rejected, feedback is stored and the pipeline
 continues regardless (there is no retry loop in the fitting phase).
 
+### No-Fitting Mode (`--no-fitting`)
+
+When `--no-fitting` is passed (or `config.fitting_enabled = False`), the fitting phase is
+replaced by a **qualitative evaluation phase**.  `N` `QualitativeEvaluationAgent` instances
+run concurrently via `asyncio.gather()`, receiving the same GPD tools as `ReviewerAgent`.
+
+Each agent evaluates all approved hypotheses against:
+- Established physical theory and first-principles arguments
+- Literature context accumulated in `LITERATURE` and `DEBATE` memory entries
+- Quantitative features extracted from user-supplied images (`IMAGE_DATA`)
+
+For each hypothesis the agent produces a verdict (SUPPORTED / PLAUSIBLE / SPECULATIVE /
+REJECTED), the specific numerical data that would be needed to upgrade to a quantitative
+fit, and the single most decisive confirming or refuting measurement.
+
+Results are synthesized via `DebateEngine.synthesize(phase="qualitative")`, stored as
+`QUALITATIVE_EVAL`, and a `FITTING_SKIPPED` flag is written to memory.  `ReviewerAgent`
+reads both kinds in its `extra_kinds` so the review phase adapts its report accordingly.
+
+The qualitative phase runs an approval loop (same as the fitting phase); rejected rounds
+store user feedback and repeat.
+
 ---
 
 ## Phase 3: Review
@@ -352,11 +381,13 @@ mtf/
 │   ├── image_digest.py     ImageDigestAgent + FileDigestSubagent
 │   ├── literature.py       LiteratureAgent
 │   ├── fitting.py          FittingAgent
+│   ├── qualitative.py      QualitativeEvaluationAgent (--no-fitting mode)
 │   ├── reviewer.py         ReviewerAgent
 │   └── tool_builder.py     ToolBuilderAgent
 ├── phases/
 │   ├── literature_phase.py convention lock + debate loop + approval gate
 │   ├── fitting_phase.py    toolkit resolution + fan-out + debate
+│   ├── qualitative_phase.py  fan-out qualitative eval + debate (--no-fitting mode)
 │   └── review_phase.py     fan-out + final debate
 ├── tools/
 │   ├── arxiv_search.py     sdk.Tool wrapping arxiv.Client

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -21,6 +21,7 @@ mtf   # interactive mode — you are prompted for everything
 | `--image-digest-model` | `claude-opus-4-6` | Model for image digestion |
 | `--images` | _(none)_ | Image files to digest (PNG, JPG, GIF, WebP) |
 | `--physics-domains` | `condensed_matter` | GPD physics domains (space-separated) |
+| `--no-fitting` | _(off)_ | Skip quantitative fitting; run qualitative hypothesis evaluation instead |
 | `--no-gpd` | _(off)_ | Disable GPD MCP physics verification |
 | `--gpd-servers` | _(all)_ | GPD servers to start |
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -12,6 +12,7 @@ mtf   # interactive mode — you are prompted for everything
 |------|---------|-------------|
 | `--n-literature` | `3` | Parallel literature agents |
 | `--n-fitting` | `3` | Parallel fitting agents per hypothesis |
+| `--n-qualitative` | `3` | Parallel qualitative evaluation agents (used with `--no-fitting`) |
 | `--n-reviewer` | `3` | Parallel reviewer agents |
 | `--max-debate-rounds` | `3` | Max debate rounds before auto-proceeding |
 | `--literature-model` | `claude-opus-4-6` | Model for literature agents |

--- a/mtf/agents/fitting.py
+++ b/mtf/agents/fitting.py
@@ -102,7 +102,7 @@ class FittingAgent(BaseAgent):
                 MemoryKind.DOMAIN_PATTERNS,
             ),
         )
-        lines = [l.strip() for l in response.splitlines() if l.strip()]
+        lines = [line.strip() for line in response.splitlines() if line.strip()]
         return lines
 
     async def fit(self, hypothesis: str) -> dict[str, object]:

--- a/mtf/agents/qualitative.py
+++ b/mtf/agents/qualitative.py
@@ -1,0 +1,63 @@
+"""QualitativeEvaluationAgent: evaluates hypotheses qualitatively when fitting is skipped."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mtf.agents.base import BaseAgent
+from mtf.memory import MemoryKind, SharedMemory
+
+_SYSTEM_PROMPT = """You are a senior physicist conducting a qualitative evaluation of hypotheses about an experimental phenomenon, in the absence of numerical fitting data.
+
+For each hypothesis provided:
+1. Assess plausibility based on established physical theory and the literature context available.
+2. Identify what observational or experimental signatures would be expected if the hypothesis is correct, referencing any image/plot data already extracted.
+3. Explicitly state what numerical data (measurements, spectra, time series, etc.) would be needed to upgrade a qualitative assessment to a quantitative fit.
+4. Rate each hypothesis: SUPPORTED (well-grounded in theory + consistent with available observations) / PLAUSIBLE (theoretically reasonable, no contradicting observations) / SPECULATIVE (possible but lacking strong theoretical or observational backing) / REJECTED (contradicted by known physics or available observations).
+5. For each non-REJECTED hypothesis, propose the single most decisive measurement that would confirm or refute it.
+
+Be rigorous. Cite specific physical arguments, known phenomena, and any quantitative features visible in the image-extracted data."""
+
+
+class QualitativeEvaluationAgent(BaseAgent):
+    def __init__(
+        self,
+        agent_id: str,
+        model: str,
+        memory: SharedMemory,
+        gpd_tools: list[Any] | None = None,
+    ) -> None:
+        extra_tools: list[Any] = gpd_tools if gpd_tools is not None else []
+        super().__init__(
+            agent_id=agent_id,
+            model=model,
+            tools=[*extra_tools],
+            memory=memory,
+            system_prompt=_SYSTEM_PROMPT,
+        )
+
+    async def evaluate(self, phenomenon: str, hypotheses: list[str]) -> str:
+        task = (
+            f"Original phenomenon:\n{phenomenon}\n\n"
+            "Hypotheses to evaluate:\n"
+            + "\n".join(f"- {h}" for h in hypotheses)
+            + "\n\nConduct a rigorous qualitative evaluation of each hypothesis."
+        )
+        result = await self._query(
+            task,
+            extra_kinds=(
+                MemoryKind.IMAGE_DATA,
+                MemoryKind.LITERATURE,
+                MemoryKind.DEBATE,
+                MemoryKind.USER_FEEDBACK,
+                MemoryKind.CONVENTIONS,
+                MemoryKind.PHYSICS_VERDICT,
+                MemoryKind.FITTING_WARNINGS,
+            ),
+        )
+        self._memory.add(
+            MemoryKind.QUALITATIVE_EVAL,
+            result,
+            agent_id=self._agent_id,
+        )
+        return result

--- a/mtf/agents/qualitative.py
+++ b/mtf/agents/qualitative.py
@@ -52,7 +52,6 @@ class QualitativeEvaluationAgent(BaseAgent):
                 MemoryKind.USER_FEEDBACK,
                 MemoryKind.CONVENTIONS,
                 MemoryKind.PHYSICS_VERDICT,
-                MemoryKind.FITTING_WARNINGS,
             ),
         )
         self._memory.add(

--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -74,6 +74,8 @@ class ReviewerAgent(BaseAgent):
                 MemoryKind.IMAGE_DATA,
                 MemoryKind.CONVENTIONS,
                 MemoryKind.PHYSICS_VERDICT,
+                MemoryKind.QUALITATIVE_EVAL,
+                MemoryKind.FITTING_SKIPPED,
             ),
         )
         self._memory.add(

--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -38,7 +38,17 @@ with the relevant check IDs cited (e.g. "REJECTED — check 5.1 FAIL: units inco
 
 Rank hypotheses by: (1) physics check results, (2) parsimony, (3) first-principles
 basis, (4) chi² last. Be rigorous, constructive, and cite specific evidence from the
-provided context."""
+provided context.
+
+If `[FITTING_SKIPPED]` appears in your context, the fitting phase was skipped and no
+`[FIT_RESULT]` entries exist for the current run. In this mode:
+- Skip steps 3–4 (fit-result checks and dimensional_check on fit results).
+- Instead, read all `[QUALITATIVE_EVAL]` entries and assess whether the qualitative
+  verdicts are well-supported by the available literature and image data.
+- Do not rank by chi² — rank by: (1) physics check results on theoretical arguments,
+  (2) parsimony, (3) first-principles basis.
+- Your recommendation should focus on what data collection would be needed to upgrade
+  qualitative assessments to quantitative fits."""
 
 
 class ReviewerAgent(BaseAgent):

--- a/mtf/cli.py
+++ b/mtf/cli.py
@@ -47,6 +47,11 @@ def build_parser() -> argparse.ArgumentParser:
         "'condensed_matter qft' for cross-domain phenomena (default: condensed_matter)",
     )
     p.add_argument(
+        "--no-fitting",
+        action="store_true",
+        help="Skip the numerical fitting phase and run a qualitative hypothesis evaluation instead",
+    )
+    p.add_argument(
         "--no-gpd",
         action="store_true",
         help="Disable GPD MCP physics verification servers",
@@ -77,6 +82,7 @@ def main() -> None:
     gpd_kwargs: dict[str, object] = {
         "enable_gpd_mcp": not args.no_gpd,
         "physics_domains": args.physics_domains,
+        "fitting_enabled": not args.no_fitting,
     }
     if args.gpd_servers is not None:
         gpd_kwargs["gpd_servers"] = args.gpd_servers

--- a/mtf/cli.py
+++ b/mtf/cli.py
@@ -22,6 +22,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--n-literature", type=int, default=3)
     p.add_argument("--n-fitting", type=int, default=3)
+    p.add_argument("--n-qualitative", type=int, default=3)
     p.add_argument("--n-reviewer", type=int, default=3)
     p.add_argument("--literature-model", default="claude-opus-4-6")
     p.add_argument("--fitting-model", default="claude-opus-4-6")
@@ -90,6 +91,7 @@ def main() -> None:
     config = MTFConfig(
         n_literature=args.n_literature,
         n_fitting=args.n_fitting,
+        n_qualitative=args.n_qualitative,
         n_reviewer=args.n_reviewer,
         literature_model=args.literature_model,
         fitting_model=args.fitting_model,

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -23,6 +23,7 @@ class MTFConfig:
     max_debate_rounds: int = 3
 
     # Fitting
+    fitting_enabled: bool = True
     fitting_scope: str = "per_hypothesis"  # "per_hypothesis" | "all"
     fitting_semaphore_limit: int = 6
 

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -10,6 +10,7 @@ class MTFConfig:
     # Agent counts
     n_literature: int = 3
     n_fitting: int = 3
+    n_qualitative: int = 3
     n_reviewer: int = 3
 
     # Model selection

--- a/mtf/debate.py
+++ b/mtf/debate.py
@@ -104,7 +104,7 @@ class DebateEngine:
         # downstream agents reading MemoryKind.DEBATE see the objective check alongside
         # the synthesis.  The same result is also stored as PHYSICS_VERDICT for targeted
         # filtering in the review phase.
-        if self._gpd is not None and phase in ("fitting", "review"):
+        if self._gpd is not None and phase in ("fitting", "review", "qualitative"):
             summary = await self._append_dimensional_check(summary, phase)
 
         self._memory.add(MemoryKind.DEBATE, summary, phase=phase)

--- a/mtf/debate.py
+++ b/mtf/debate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import anthropic
 

--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -107,6 +107,7 @@ def _streamlit_app() -> None:
         n_fitting = st.slider("Fitting agents", 1, 6, 3)
         n_reviewer = st.slider("Reviewer agents", 1, 6, 3)
         max_debate_rounds = st.slider("Max debate rounds", 1, 5, 3)
+        skip_fitting = st.checkbox("Skip fitting phase (qualitative evaluation only)", value=False)
 
         physics_domain_options = [
             "condensed_matter",
@@ -159,6 +160,7 @@ def _streamlit_app() -> None:
                 max_debate_rounds=max_debate_rounds,
                 physics_domains=physics_domains or ["condensed_matter"],
                 enable_gpd_mcp=enable_gpd,
+                fitting_enabled=not skip_fitting,
             )
 
             ui_queue: "queue.Queue[tuple[str, Any, Any]]" = queue.Queue()

--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -108,6 +108,7 @@ def _streamlit_app() -> None:
         n_reviewer = st.slider("Reviewer agents", 1, 6, 3)
         max_debate_rounds = st.slider("Max debate rounds", 1, 5, 3)
         skip_fitting = st.checkbox("Skip fitting phase (qualitative evaluation only)", value=False)
+        n_qualitative = st.slider("Qualitative evaluation agents", 1, 6, 3)
 
         physics_domain_options = [
             "condensed_matter",
@@ -156,6 +157,7 @@ def _streamlit_app() -> None:
             config = MTFConfig(
                 n_literature=n_literature,
                 n_fitting=n_fitting,
+                n_qualitative=n_qualitative,
                 n_reviewer=n_reviewer,
                 max_debate_rounds=max_debate_rounds,
                 physics_domains=physics_domains or ["condensed_matter"],

--- a/mtf/memory.py
+++ b/mtf/memory.py
@@ -22,6 +22,8 @@ class MemoryKind(str, Enum):
     FITTING_WARNINGS = "fitting_warnings"  # pre-dispatch pitfall warnings from pattern library + error classes
     DOMAIN_PATTERNS = "domain_patterns"    # cross-session patterns pre-fetched at literature phase start
     DOMAIN_CLASSIFICATION = "domain_classification"  # auto-detected domain classification (audit trail)
+    QUALITATIVE_EVAL = "qualitative_eval"  # qualitative hypothesis evaluation (used when fitting is skipped)
+    FITTING_SKIPPED = "fitting_skipped"    # marker written when --no-fitting is active
 
 
 @dataclass

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -13,6 +13,7 @@ from mtf.interface import CLIInterface, HumanInterface
 from mtf.memory import MemoryKind, SharedMemory
 from mtf.phases.fitting_phase import run_fitting_phase
 from mtf.phases.literature_phase import run_literature_phase
+from mtf.phases.qualitative_phase import run_qualitative_phase
 from mtf.phases.review_phase import run_review_phase
 from mtf.toolkit.registry import ToolkitRegistry
 from mtf.tools.gpd_mcp import GPDMCPClient
@@ -166,16 +167,27 @@ class MTFOrchestrator:
                 gpd=gpd,
             )
 
-            # Phase 2: Fitting
-            await run_fitting_phase(
-                hypotheses=hypotheses,
-                config=self._config,
-                memory=self._memory,
-                interface=self._interface,
-                debate_engine=debate,
-                toolkit=self._toolkit,
-                gpd=gpd,
-            )
+            # Phase 2: Fitting (or qualitative evaluation if fitting is disabled)
+            if self._config.fitting_enabled:
+                await run_fitting_phase(
+                    hypotheses=hypotheses,
+                    config=self._config,
+                    memory=self._memory,
+                    interface=self._interface,
+                    debate_engine=debate,
+                    toolkit=self._toolkit,
+                    gpd=gpd,
+                )
+            else:
+                await run_qualitative_phase(
+                    phenomenon=phenomenon,
+                    hypotheses=hypotheses,
+                    config=self._config,
+                    memory=self._memory,
+                    interface=self._interface,
+                    debate_engine=debate,
+                    gpd=gpd,
+                )
 
             # Phase 3: Review
             final_report = await run_review_phase(

--- a/mtf/phases/qualitative_phase.py
+++ b/mtf/phases/qualitative_phase.py
@@ -25,12 +25,6 @@ async def run_qualitative_phase(
 
     Used as a substitute for the fitting phase when ``config.fitting_enabled`` is False.
     """
-    await interface.show(
-        f"**Qualitative evaluation phase** — no fitting data available. "
-        f"Dispatching {config.n_fitting} qualitative evaluation agents...",
-        title="MTF: Qualitative Evaluation",
-    )
-
     # Build GPD tools for QualitativeEvaluationAgent — same set as ReviewerAgent
     gpd_tools: list[Any] = []
     if gpd is not None:
@@ -72,37 +66,47 @@ async def run_qualitative_phase(
                 "description, detection, prevention, example, test_value."),
         ] if t is not None]
 
-    # Fan-out: create n_fitting QualitativeEvaluationAgent instances and gather results
-    agents = [
-        QualitativeEvaluationAgent(
-            agent_id=f"qual-{i}",
-            model=config.fitting_model,
-            memory=memory,
-            gpd_tools=gpd_tools,
+    synthesis = ""
+    for round_num in range(1, config.max_debate_rounds + 1):
+        await interface.show(
+            f"**Qualitative evaluation phase — round {round_num}/{config.max_debate_rounds}** "
+            f"— no fitting data available. "
+            f"Dispatching {config.n_qualitative} qualitative evaluation agents...",
+            title="MTF: Qualitative Evaluation",
         )
-        for i in range(config.n_fitting)
-    ]
-    reports = await asyncio.gather(
-        *(a.evaluate(phenomenon, hypotheses) for a in agents)
-    )
 
-    synthesis = await debate_engine.synthesize(
-        list(reports),
-        phase="qualitative",
-        extra_context=f"Phenomenon: {phenomenon}\nHypotheses: {hypotheses}",
-    )
+        # Fan-out: create n_qualitative QualitativeEvaluationAgent instances and gather results
+        agents = [
+            QualitativeEvaluationAgent(
+                agent_id=f"qual-{i}",
+                model=config.fitting_model,
+                memory=memory,
+                gpd_tools=gpd_tools,
+            )
+            for i in range(config.n_qualitative)
+        ]
+        reports = await asyncio.gather(
+            *(a.evaluate(phenomenon, hypotheses) for a in agents)
+        )
 
-    await interface.show(synthesis, title="Qualitative Evaluation")
+        # Mark fitting as skipped before synthesis so DebateEngine sees it in context
+        memory.add(
+            MemoryKind.FITTING_SKIPPED,
+            "Fitting phase was skipped (--no-fitting). Qualitative evaluation substituted.",
+        )
 
-    # Mark fitting as skipped
-    memory.add(
-        MemoryKind.FITTING_SKIPPED,
-        "Fitting phase was skipped (--no-fitting). Qualitative evaluation substituted.",
-    )
+        synthesis = await debate_engine.synthesize(
+            list(reports),
+            phase="qualitative",
+            extra_context=f"Phenomenon: {phenomenon}\nHypotheses: {hypotheses}",
+        )
 
-    # User approval loop
-    approved = await interface.confirm("Do you approve the qualitative evaluation?")
-    if not approved:
+        await interface.show(synthesis, title=f"Qualitative Evaluation (round {round_num})")
+
+        approved = await interface.confirm("Do you approve the qualitative evaluation?")
+        if approved:
+            break
+
         feedback = await interface.ask("Guidance for qualitative evaluation?")
         if feedback.strip():
             memory.add(MemoryKind.USER_FEEDBACK, feedback)

--- a/mtf/phases/qualitative_phase.py
+++ b/mtf/phases/qualitative_phase.py
@@ -1,0 +1,110 @@
+"""Qualitative evaluation phase: fan-out qualitative agents, debate, approval loop."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from mtf.agents.qualitative import QualitativeEvaluationAgent
+from mtf.config import MTFConfig
+from mtf.debate import DebateEngine
+from mtf.interface import HumanInterface
+from mtf.memory import MemoryKind, SharedMemory
+
+
+async def run_qualitative_phase(
+    phenomenon: str,
+    hypotheses: list[str],
+    config: MTFConfig,
+    memory: SharedMemory,
+    interface: HumanInterface,
+    debate_engine: DebateEngine,
+    gpd: Any | None = None,
+) -> str:
+    """Fan out qualitative evaluation agents and synthesize results.
+
+    Used as a substitute for the fitting phase when ``config.fitting_enabled`` is False.
+    """
+    await interface.show(
+        f"**Qualitative evaluation phase** — no fitting data available. "
+        f"Dispatching {config.n_fitting} qualitative evaluation agents...",
+        title="MTF: Qualitative Evaluation",
+    )
+
+    # Build GPD tools for QualitativeEvaluationAgent — same set as ReviewerAgent
+    gpd_tools: list[Any] = []
+    if gpd is not None:
+        gpd_tools = [t for t in [
+            gpd.make_tool("verification", "get_checklist",
+                "Get the domain-specific physics verification checklist. "
+                "Input: domain (str, e.g. condensed_matter, qft, gr, amo). "
+                "Returns list of check IDs and descriptions. Call this FIRST, "
+                "once per domain if the phenomenon spans multiple domains, "
+                "and merge the resulting checklists."),
+            gpd.make_tool("verification", "run_check",
+                "Run a specific physics verification check against a fit result or hypothesis text. "
+                "Input: check_id (str: '5.1'=dimensional, '5.2'=symmetry, '5.3'=limiting_cases, "
+                "'5.4'=conservation, '5.5'=convergence, '5.18'=fit_family_mismatch), "
+                "domain (str), artifact_content (str of the fit result). "
+                "Returns automated issues found."),
+            gpd.make_tool("verification", "dimensional_check",
+                "Check dimensional consistency of physics equations. "
+                "Input: expressions (list of strings like '[M][L]^2[T]^-2 = [M][L]^2[T]^-2'). "
+                "Returns pass/fail per expression."),
+            gpd.make_tool("verification", "limiting_case_check",
+                "Verify that a model's limiting cases are documented and correct. "
+                "Input: expression (str), limits (dict mapping limit description to expected result)."),
+            gpd.make_tool("errors", "check_error_classes",
+                "Given a physics computation description, return the top-15 relevant error classes "
+                "from a catalog of 104 known physics errors. Call this early in your review "
+                "to know what specific mistakes to hunt for."),
+            gpd.make_tool("errors", "get_detection_strategy",
+                "Get the detection strategy for a specific physics error class by ID (int 1-104). "
+                "Use after check_error_classes identifies relevant error classes."),
+            gpd.make_tool("patterns", "lookup_pattern",
+                "Search the persistent cross-session physics error pattern library. "
+                "Input: domain (str), category (str: sign-error/factor-error/convention-pitfall/"
+                "convergence-issue/approximation-failure/dimensional-error), keywords (str). "
+                "Returns known patterns from previous runs."),
+            gpd.make_tool("patterns", "add_pattern",
+                "Record a newly discovered physics error pattern for future reference across sessions. "
+                "Input: domain, title, category, severity (low/medium/high/critical), "
+                "description, detection, prevention, example, test_value."),
+        ] if t is not None]
+
+    # Fan-out: create n_fitting QualitativeEvaluationAgent instances and gather results
+    agents = [
+        QualitativeEvaluationAgent(
+            agent_id=f"qual-{i}",
+            model=config.fitting_model,
+            memory=memory,
+            gpd_tools=gpd_tools,
+        )
+        for i in range(config.n_fitting)
+    ]
+    reports = await asyncio.gather(
+        *(a.evaluate(phenomenon, hypotheses) for a in agents)
+    )
+
+    synthesis = await debate_engine.synthesize(
+        list(reports),
+        phase="qualitative",
+        extra_context=f"Phenomenon: {phenomenon}\nHypotheses: {hypotheses}",
+    )
+
+    await interface.show(synthesis, title="Qualitative Evaluation")
+
+    # Mark fitting as skipped
+    memory.add(
+        MemoryKind.FITTING_SKIPPED,
+        "Fitting phase was skipped (--no-fitting). Qualitative evaluation substituted.",
+    )
+
+    # User approval loop
+    approved = await interface.confirm("Do you approve the qualitative evaluation?")
+    if not approved:
+        feedback = await interface.ask("Guidance for qualitative evaluation?")
+        if feedback.strip():
+            memory.add(MemoryKind.USER_FEEDBACK, feedback)
+
+    return synthesis


### PR DESCRIPTION
## Summary

- Adds `--no-fitting` CLI flag (and `fitting_enabled` config field) to skip quantitative fitting when users lack the necessary data
- When fitting is skipped, a new `QualitativeEvaluationAgent` fan-out runs instead, evaluating each hypothesis against theory, literature, and image-extracted data and producing SUPPORTED/PLAUSIBLE/SPECULATIVE/REJECTED verdicts
- `ReviewerAgent` reads `QUALITATIVE_EVAL` and `FITTING_SKIPPED` memory entries so the review phase adapts accordingly
- GUI: "Skip fitting phase" checkbox added to sidebar

## New files
- `mtf/agents/qualitative.py` — `QualitativeEvaluationAgent`
- `mtf/phases/qualitative_phase.py` — `run_qualitative_phase()`

## Docs updated
- Architecture overview: pipeline diagram with fitting/qualitative branch; no-fitting mode subsection
- `docs/architecture/agents.md`: `QualitativeEvaluationAgent` section
- `docs/architecture/memory.md`: `QUALITATIVE_EVAL`, `FITTING_SKIPPED` kinds; accumulation order showing both paths
- `docs/usage/cli.md`: `--no-fitting` flag

## Test plan
- [ ] `mtf "phenomenon" --no-fitting` runs without error and produces a qualitative evaluation + review report
- [ ] Without `--no-fitting`, existing fitting path is unchanged
- [ ] GUI checkbox correctly toggles `fitting_enabled`
- [ ] `ReviewerAgent` report mentions qualitative evaluation context when fitting was skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)