### PR TITLE
Enhanced PDF extraction with two-pass figure analysis

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -51,10 +51,20 @@ A stateless, leaf-level worker that digests exactly one file.  It does not touch
   all axis labels and units and scale, every data series as a Python list of numbers,
   key quantitative features (peaks, plateaus, slopes, error bars, fit parameters),
   embedded annotations, and a brief physical interpretation.
-- **PDFs**: sends a content block of type `"document"` with base64 PDF data.  The system
-  prompt asks for: document type, title, authors, physical system and phenomena, key equations
-  (reproduced symbolically with symbol definitions), experimental methods and parameters,
-  all reported numerical values with units, and main conclusions.
+- **PDFs**: sends a content block of type `"document"` with base64 PDF data.
+
+  **Standard pass** (`_PDF_SYSTEM_PROMPT`): extracts document type, title, authors, physical
+  system, key equations (reproduced symbolically), experimental methods and parameters, all
+  reported numerical values with units, conclusions, and a **Figure Inventory** listing every
+  figure by page number and caption.
+
+  **Figure-extraction pass** (`_FIGURE_EXTRACTION_PROMPT`, enabled when
+  `config.pdf_enhanced_extraction = True`): a second API call with the same document block,
+  using a dedicated prompt that iterates page-by-page and extracts each figure individually —
+  type, axes (labels, units, scale, range), every data series as numerical arrays, key
+  quantitative features, and physical significance.  The two pass results are combined into a
+  single sectioned digest: `## General Document Digest` followed by
+  `## Figure-by-Figure Extraction`.
 
 The MIME type is detected via `mimetypes.guess_type()`; unrecognised formats default to
 `image/png`.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -99,9 +99,15 @@ can access extracted numerical data.
      type, axis labels and units, all data series as Python lists of numbers, key quantitative
      features (peaks, plateaus, slopes, error bars, fit parameters), embedded annotations, and
      a brief physical interpretation.
-   - **PDFs**: a separate system prompt asks for document type, physical system, key equations
-     (reproduced symbolically), experimental methods and parameters, all reported numerical
-     values with units and uncertainties, and conclusions.
+   - **PDFs**: processed in up to two passes when `config.pdf_enhanced_extraction = True` (default).
+     - *Pass 1 (general digest):* the full PDF is sent with `_PDF_SYSTEM_PROMPT`, which extracts
+       document metadata, physical system, key equations, experimental methods, all reported numerical
+       values, conclusions, and a Figure Inventory enumerating every figure by page.
+     - *Pass 2 (figure extraction):* the same PDF is sent again with `_FIGURE_EXTRACTION_PROMPT`,
+       which iterates page-by-page and extracts each figure individually — type, axes, data series
+       as numerical arrays, quantitative features, and physical significance.
+     - Both results are concatenated into a single structured digest.  When `pdf_enhanced_extraction = False`,
+       only Pass 1 runs (same as the pre-existing behaviour).
 3. Each digest is stored in `SharedMemory` as `MemoryKind.IMAGE_DATA` with
    `source_file` and `filename` metadata.
 4. If more than one file was provided, a second synthesis `messages.create()` call combines

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -27,6 +27,7 @@ mtf   # interactive mode — you are prompted for everything
 | `--no-fitting` | _(off)_ | Skip quantitative fitting; run qualitative hypothesis evaluation instead |
 | `--no-gpd` | _(off)_ | Disable GPD MCP physics verification |
 | `--gpd-servers` | _(all)_ | GPD servers to start |
+| `--no-enhanced-pdf` | _(off)_ | Use single-pass PDF extraction instead of the default two-pass figure analysis |
 
 ## Examples
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -2,7 +2,7 @@
 
 ```bash
 mtf "Describe your phenomenon here"
-mtf "Describe your phenomenon here" --images plot1.png plot2.png
+mtf "Describe your phenomenon here" --files plot1.png plot2.png
 mtf   # interactive mode — you are prompted for everything
 ```
 
@@ -22,7 +22,7 @@ mtf   # interactive mode — you are prompted for everything
 | `--proposal-model` | `claude-opus-4-6` | Model for proposal agents |
 | `--debate-model` | `claude-opus-4-6` | Model for debate synthesis |
 | `--image-digest-model` | `claude-opus-4-6` | Model for image digestion |
-| `--images` | _(none)_ | Image files to digest (PNG, JPG, GIF, WebP) |
+| `--files` | _(none)_ | Input files to digest (images: PNG, JPG, GIF, WebP; documents: PDF) |
 | `--physics-domains` | `condensed_matter` | GPD physics domains (space-separated) |
 | `--no-fitting` | _(off)_ | Skip quantitative fitting; run qualitative hypothesis evaluation instead |
 | `--no-gpd` | _(off)_ | Disable GPD MCP physics verification |
@@ -33,7 +33,7 @@ mtf   # interactive mode — you are prompted for everything
 
 ```bash
 # Quantum Hall phenomenon with two images
-mtf "Plateau in rho_xx at B=3T" --images rho.png Hall.png
+mtf "Plateau in rho_xx at B=3T" --files rho.png Hall.png
 
 # Cross-domain (neutron star)
 mtf "Neutron star cooling anomaly" --physics-domains gr nuclear amo

--- a/docs/usage/gui.md
+++ b/docs/usage/gui.md
@@ -14,6 +14,7 @@ Opens `http://localhost:8501`.
 - **Debate rounds** — max synthesis iterations per phase
 - **Physics domains** — GPD domain list (e.g. `condensed_matter`, `qft`, `nuclear`)
 - **GPD toggle** — enable or disable physics verification servers
+- **Enhanced PDF extraction** — enable/disable the two-pass figure-extraction pipeline for PDF documents
 - **Models** — select Claude model per agent type
 
 ## Workflow

--- a/docs/usage/images.md
+++ b/docs/usage/images.md
@@ -1,10 +1,10 @@
-# Providing Images
+# Providing Images and PDFs
 
-MTF reads quantitative information from experimental images using Claude's vision API.
+MTF reads quantitative information from experimental images and PDF documents using Claude's vision API.
+
+## Images (PNG, JPG, GIF, WebP)
 
 **Supported formats:** PNG, JPG, GIF, WebP.
-
-## What gets extracted
 
 For each image, `ImageDigestAgent` produces a structured digest containing:
 
@@ -16,10 +16,56 @@ For each image, `ImageDigestAgent` produces a structured digest containing:
 
 The digest is stored as `MemoryKind.IMAGE_DATA` in `SharedMemory` and is automatically included in the context of every literature, fitting, and reviewer agent. Fitting agents can use plot-extracted data directly, even without registered toolkit arrays.
 
+## PDFs
+
+MTF supports PDF documents (research papers, lab notes, preprints). Pass a PDF the same way as an image:
+
+```bash
+mtf "Describe phenomenon" --images notes.pdf figure.png
+```
+
+### Standard extraction (single pass)
+
+By default, `FileDigestSubagent` sends the full PDF to the API and extracts:
+
+- Document type, title, authors, and summary
+- Physical system studied and key phenomena
+- All central equations reproduced symbolically with symbol definitions
+- Experimental setup, techniques, sample parameters, and calibration details
+- All reported numerical values with units and uncertainties
+- Fitting parameters and critical scales (temperatures, fields, frequencies)
+- Key conclusions and proposed mechanisms
+- A **Figure Inventory**: every figure, graph, plot, table, and diagram enumerated with page number, caption, and a one-line description
+
+### Enhanced extraction (two-pass, default)
+
+For dense documents (many figures, 10+ pages), MTF runs a second targeted pass using a
+dedicated figure-extraction prompt.  This is enabled by default (`config.pdf_enhanced_extraction = True`).
+
+**Pass 1 — General digest:** The full PDF is sent with the standard scientific overview prompt, which now includes a Figure Inventory section listing every figure by page.
+
+**Pass 2 — Figure-by-figure extraction:** The same PDF is sent again with a focused prompt that iterates page-by-page and for each figure extracts:
+- Caption text (verbatim)
+- Figure type (scatter plot, line graph, heatmap, table, schematic, etc.)
+- All axis labels, units, scale (linear/log), and full numeric range
+- Every data series as extracted numerical arrays: `x = [...], y = [...]`
+- Key quantitative features: peaks, plateaus, slopes, error bars, fit parameters
+- Physical significance in one sentence
+
+Both pass results are combined into a single structured digest stored in `SharedMemory` as `IMAGE_DATA`.
+
+### Disabling enhanced extraction
+
+Pass `--no-enhanced-pdf` on the CLI (or set `config.pdf_enhanced_extraction = False` in Python) to use only the single-pass path. Useful when the PDF is short (< 5 pages) or contains no figures.
+
+### Why no new dependencies?
+
+Both passes use the same Anthropic messages API call that is already used for images — the PDF is base64-encoded and sent as a `"document"` content block. No PDF parsing library is required.
+
 ## CLI
 
 ```bash
-mtf "Describe phenomenon" --images figure1.png figure2.jpg
+mtf "Describe phenomenon" --images paper.pdf figure.png
 ```
 
 ## Python API

--- a/docs/usage/images.md
+++ b/docs/usage/images.md
@@ -21,7 +21,7 @@ The digest is stored as `MemoryKind.IMAGE_DATA` in `SharedMemory` and is automat
 MTF supports PDF documents (research papers, lab notes, preprints). Pass a PDF the same way as an image:
 
 ```bash
-mtf "Describe phenomenon" --images notes.pdf figure.png
+mtf "Describe phenomenon" --files notes.pdf figure.png
 ```
 
 ### Standard extraction (single pass)
@@ -54,9 +54,13 @@ dedicated figure-extraction prompt.  This is enabled by default (`config.pdf_enh
 
 Both pass results are combined into a single structured digest stored in `SharedMemory` as `IMAGE_DATA`.
 
+**Pass 1 and Pass 2 run in parallel** (`asyncio.gather()`), so the two-pass path adds no wall-clock latency over a hypothetical sequential run. Pass 2 uses `pdf_figure_extraction_max_tokens` (default **8192**) to accommodate dense figure-heavy documents; if a response is still truncated, MTF logs a warning and you can raise this value in `MTFConfig`.
+
 ### Disabling enhanced extraction
 
-Pass `--no-enhanced-pdf` on the CLI (or set `config.pdf_enhanced_extraction = False` in Python) to use only the single-pass path. Useful when the PDF is short (< 5 pages) or contains no figures.
+Pass `--no-enhanced-pdf` on the CLI (or set `config.pdf_enhanced_extraction = False` in Python) to use only the single-pass path. Useful when the PDF is short or contains no figures.
+
+The two-pass path also has a **file-size guard**: if the PDF is smaller than `config.pdf_min_size_kb_for_enhanced` (default **200 KB**), MTF automatically falls back to single-pass extraction, avoiding the overhead of a second API call for trivially short documents. You can lower or raise this threshold in `MTFConfig`.
 
 ### Why no new dependencies?
 
@@ -65,17 +69,17 @@ Both passes use the same Anthropic messages API call that is already used for im
 ## CLI
 
 ```bash
-mtf "Describe phenomenon" --images paper.pdf figure.png
+mtf "Describe phenomenon" --files paper.pdf figure.png
 ```
 
 ## Python API
 
 ```python
 report = asyncio.run(
-    orchestrator.run("Describe phenomenon", images=["figure1.png"])
+    orchestrator.run("Describe phenomenon", files=["figure1.png"])
 )
 ```
 
 ## Interactive mode
 
-When no `--images` flag is given, the CLI asks whether you have images to provide before starting the analysis.
+When no `--files` flag is given, the CLI asks whether you have files to provide before starting the analysis.

--- a/mtf/agents/image_digest.py
+++ b/mtf/agents/image_digest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import mimetypes
+import warnings
 from pathlib import Path
 
 import anthropic
@@ -202,47 +203,66 @@ class FileDigestSubagent:
                 f"equations, numerical results, and conclusions as described."
             )
 
-            if self._config.pdf_enhanced_extraction:
-                # Call 1: general digest
-                response1 = await asyncio.to_thread(
-                    self._client.messages.create,
-                    model=self._config.image_digest_model,
-                    max_tokens=4096,
-                    system=_PDF_SYSTEM_PROMPT,
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": [
-                                content_block,
-                                {"type": "text", "text": user_text},
-                            ],
-                        }
-                    ],
-                )
-                general_digest: str = response1.content[0].text  # type: ignore[index]
+            file_size_kb = path.stat().st_size / 1024
+            run_enhanced = (
+                self._config.pdf_enhanced_extraction
+                and file_size_kb >= self._config.pdf_min_size_kb_for_enhanced
+            )
 
-                # Call 2: figure extraction
+            if run_enhanced:
+                # Pass 1 (general digest) and Pass 2 (figure extraction) run in parallel.
                 figure_user_text = (
                     f"Extract every figure, graph, plot, and table from this document "
                     f"(filename: {path.name}). For each figure, provide the full quantitative "
                     f"extraction as instructed. Work through the document page by page — "
                     f"do not skip any figure."
                 )
-                response2 = await asyncio.to_thread(
-                    self._client.messages.create,
-                    model=self._config.image_digest_model,
-                    max_tokens=self._config.pdf_figure_extraction_max_tokens,
-                    system=_FIGURE_EXTRACTION_PROMPT,
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": [
-                                content_block,
-                                {"type": "text", "text": figure_user_text},
-                            ],
-                        }
-                    ],
+                response1, response2 = await asyncio.gather(
+                    asyncio.to_thread(
+                        self._client.messages.create,
+                        model=self._config.image_digest_model,
+                        max_tokens=4096,
+                        system=_PDF_SYSTEM_PROMPT,
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": [
+                                    content_block,
+                                    {"type": "text", "text": user_text},
+                                ],
+                            }
+                        ],
+                    ),
+                    asyncio.to_thread(
+                        self._client.messages.create,
+                        model=self._config.image_digest_model,
+                        max_tokens=self._config.pdf_figure_extraction_max_tokens,
+                        system=_FIGURE_EXTRACTION_PROMPT,
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": [
+                                    content_block,
+                                    {"type": "text", "text": figure_user_text},
+                                ],
+                            }
+                        ],
+                    ),
                 )
+                if response1.stop_reason == "max_tokens":
+                    warnings.warn(
+                        f"PDF general digest for {path.name} was truncated (max_tokens=4096). "
+                        "Consider using a shorter document or splitting the PDF.",
+                        stacklevel=2,
+                    )
+                if response2.stop_reason == "max_tokens":
+                    warnings.warn(
+                        f"PDF figure extraction for {path.name} was truncated "
+                        f"(max_tokens={self._config.pdf_figure_extraction_max_tokens}). "
+                        "Consider increasing pdf_figure_extraction_max_tokens in MTFConfig.",
+                        stacklevel=2,
+                    )
+                general_digest: str = response1.content[0].text  # type: ignore[index]
                 figure_digest: str = response2.content[0].text  # type: ignore[index]
 
                 return (
@@ -381,7 +401,7 @@ class ImageDigestAgent:
         response = await asyncio.to_thread(
             self._client.messages.create,
             model=self._config.image_digest_model,
-            max_tokens=4096,
+            max_tokens=8192,
             system=_SYNTHESIS_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_content}],
         )

--- a/mtf/agents/image_digest.py
+++ b/mtf/agents/image_digest.py
@@ -89,7 +89,37 @@ mechanisms or interpretations.
 Note any direct connections to anomalous, unexplained, or noteworthy experimental
 observations that would be relevant to a broader physics research analysis.
 
+## Figure Inventory
+List every figure, graph, plot, table, or diagram in the document in order of appearance.
+For each: page number, figure number/label (if any), caption (if any), and a one-line description
+of what it shows. This inventory helps identify which figures to extract in detail.
+
 Be precise with numbers and units. Use scientific notation where appropriate."""
+
+_FIGURE_EXTRACTION_PROMPT = """You are an expert physicist performing targeted extraction of
+figures, plots, and quantitative data from a scientific PDF document.
+
+Your ONLY task is to enumerate and extract every figure, graph, plot, diagram, and table in the
+document. For each one:
+
+## Figure N (page X)
+**Caption**: [exact caption text if present]
+**Type**: [scatter plot / line graph / heatmap / bar chart / table / schematic / photograph / etc.]
+**Axes**:
+  - x-axis: [label, unit, scale (linear/log), range]
+  - y-axis: [label, unit, scale (linear/log), range]
+  - (add z-axis or colorbar if applicable)
+**Data Series**: For each curve, dataset, or histogram:
+  - Name/label: [from legend or inferred]
+  - Extracted values: x = [...], y = [...] (best-estimate numerical lists)
+  - If values are not readable: describe the trend quantitatively (e.g., "monotonically increasing from ~0.1 to ~10 over the x-range")
+**Key Features**:
+  - List specific quantitative features: peaks at x=..., plateau at y=..., slope=..., error bars=±...
+  - List any fit parameters or annotations visible in the figure
+**Physical significance**: one sentence on what this figure shows physically
+
+If the document contains no figures or only schematics with no numerical data, state that explicitly.
+Do NOT summarise the text. Focus exclusively on figures and quantitative data."""
 
 _SYNTHESIS_SYSTEM_PROMPT = """You are an expert physicist synthesizing information
 from multiple experimental files (images, plots, papers, and notes).
@@ -166,12 +196,77 @@ class FileDigestSubagent:
                     "data": b64_data,
                 },
             }
-            system = _PDF_SYSTEM_PROMPT
             user_text = (
                 f"Please provide a complete scientific digest of this document "
                 f"(filename: {path.name}). Extract all key physics content, "
                 f"equations, numerical results, and conclusions as described."
             )
+
+            if self._config.pdf_enhanced_extraction:
+                # Call 1: general digest
+                response1 = await asyncio.to_thread(
+                    self._client.messages.create,
+                    model=self._config.image_digest_model,
+                    max_tokens=4096,
+                    system=_PDF_SYSTEM_PROMPT,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                content_block,
+                                {"type": "text", "text": user_text},
+                            ],
+                        }
+                    ],
+                )
+                general_digest: str = response1.content[0].text  # type: ignore[index]
+
+                # Call 2: figure extraction
+                figure_user_text = (
+                    f"Extract every figure, graph, plot, and table from this document "
+                    f"(filename: {path.name}). For each figure, provide the full quantitative "
+                    f"extraction as instructed. Work through the document page by page — "
+                    f"do not skip any figure."
+                )
+                response2 = await asyncio.to_thread(
+                    self._client.messages.create,
+                    model=self._config.image_digest_model,
+                    max_tokens=self._config.pdf_figure_extraction_max_tokens,
+                    system=_FIGURE_EXTRACTION_PROMPT,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                content_block,
+                                {"type": "text", "text": figure_user_text},
+                            ],
+                        }
+                    ],
+                )
+                figure_digest: str = response2.content[0].text  # type: ignore[index]
+
+                return (
+                    f"## General Document Digest\n\n{general_digest}\n\n"
+                    f"---\n\n"
+                    f"## Figure-by-Figure Extraction\n\n{figure_digest}"
+                )
+            else:
+                response = await asyncio.to_thread(
+                    self._client.messages.create,
+                    model=self._config.image_digest_model,
+                    max_tokens=4096,
+                    system=_PDF_SYSTEM_PROMPT,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                content_block,
+                                {"type": "text", "text": user_text},
+                            ],
+                        }
+                    ],
+                )
+                return response.content[0].text  # type: ignore[index]
         else:
             content_block = {
                 "type": "image",
@@ -187,23 +282,22 @@ class FileDigestSubagent:
                 f"(filename: {path.name}). Extract all numerical data and "
                 f"physically significant features as described in your instructions."
             )
-
-        response = await asyncio.to_thread(
-            self._client.messages.create,
-            model=self._config.image_digest_model,
-            max_tokens=4096,
-            system=system,
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        content_block,
-                        {"type": "text", "text": user_text},
-                    ],
-                }
-            ],
-        )
-        return response.content[0].text  # type: ignore[index]
+            response = await asyncio.to_thread(
+                self._client.messages.create,
+                model=self._config.image_digest_model,
+                max_tokens=4096,
+                system=system,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            content_block,
+                            {"type": "text", "text": user_text},
+                        ],
+                    }
+                ],
+            )
+            return response.content[0].text  # type: ignore[index]
 
 
 class ImageDigestAgent:

--- a/mtf/cli.py
+++ b/mtf/cli.py
@@ -60,6 +60,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Disable GPD MCP physics verification servers",
     )
     p.add_argument(
+        "--no-enhanced-pdf",
+        action="store_true",
+        help="Use single-pass PDF extraction instead of the default two-pass figure analysis",
+    )
+    p.add_argument(
         "--gpd-servers",
         nargs="+",
         metavar="SERVER",
@@ -103,6 +108,7 @@ def main() -> None:
         debate_model=args.debate_model,
         max_debate_rounds=args.max_debate_rounds,
         image_digest_model=args.image_digest_model,
+        pdf_enhanced_extraction=not args.no_enhanced_pdf,
         **gpd_kwargs,  # type: ignore[arg-type]
     )
     orchestrator = MTFOrchestrator(config=config)

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -55,4 +55,5 @@ class MTFConfig:
 
     # PDF enhanced extraction
     pdf_enhanced_extraction: bool = True
-    pdf_figure_extraction_max_tokens: int = 4096
+    pdf_figure_extraction_max_tokens: int = 8192
+    pdf_min_size_kb_for_enhanced: int = 200

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -52,3 +52,7 @@ class MTFConfig:
     # Proposal agent
     n_proposal: int = 2
     proposal_model: str = "claude-opus-4-6"
+
+    # PDF enhanced extraction
+    pdf_enhanced_extraction: bool = True
+    pdf_figure_extraction_max_tokens: int = 4096

--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -139,6 +139,7 @@ def _streamlit_app() -> None:
             index=0,
         )
         enable_gpd = st.checkbox("Enable GPD physics verification", value=True)
+        enhanced_pdf = st.checkbox("Enhanced PDF extraction (2-pass figure analysis)", value=True)
 
     # ------------------------------------------------------------------
     # Pre-run view
@@ -177,6 +178,7 @@ def _streamlit_app() -> None:
                 fitting_enabled=not skip_fitting,
                 reviewer_model=reviewer_model,
                 proposal_model=proposal_model,
+                pdf_enhanced_extraction=enhanced_pdf,
             )
 
             ui_queue: "queue.Queue[tuple[str, Any, Any]]" = queue.Queue()


### PR DESCRIPTION
## Summary

- Adds a two-pass extraction pipeline for dense PDFs (10+ pages, many figures) using no new dependencies
- **Pass 1** (general digest): existing `_PDF_SYSTEM_PROMPT`, now extended with a Figure Inventory section listing every figure by page number and caption
- **Pass 2** (figure extraction): new `_FIGURE_EXTRACTION_PROMPT` iterates page-by-page and extracts each figure individually — type, axes (labels/units/scale/range), all data series as numerical arrays, quantitative features, physical significance
- Enabled by default (`pdf_enhanced_extraction = True`); disable with `--no-enhanced-pdf`
- GUI: "Enhanced PDF extraction (2-pass)" checkbox added to sidebar

## Config additions
- `pdf_enhanced_extraction: bool = True`
- `pdf_figure_extraction_max_tokens: int = 4096`

## Docs updated
- `docs/usage/images.md`: major update — full PDF section with pass-by-pass description
- `docs/usage/cli.md`: `--no-enhanced-pdf` flag
- `docs/usage/gui.md`: enhanced PDF extraction sidebar control
- `docs/architecture/agents.md`: `FileDigestSubagent` updated for both passes
- `docs/architecture/overview.md`: Phase 0 updated with two-pass description

## Test plan
- [ ] A 20-page PDF with many figures produces a digest with both `## General Document Digest` and `## Figure-by-Figure Extraction` sections
- [ ] Each figure is individually enumerated with numerical data
- [ ] `--no-enhanced-pdf` produces only a single-pass digest (existing behaviour)
- [ ] Short PDFs (< 5 pages) still work correctly with enhanced mode on

🤖 Generated with [Claude Code](https://claude.com/claude-code)