### PR TITLE
Deduplicate _strip_fences into shared mtf.utils.strip_fences

### DIFF
--- a/mtf/agents/fitting.py
+++ b/mtf/agents/fitting.py
@@ -9,6 +9,7 @@ from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
 from mtf.toolkit.registry import ToolkitRegistry
 from mtf.tools.fitting_tools import run_fitting_code
+from mtf.utils import strip_fences
 
 if TYPE_CHECKING:
     from mtf.config import MTFConfig
@@ -42,22 +43,6 @@ experimental physics. Given a hypothesis and experimental data, you:
    runs on this domain.
 
 Always write clean, well-commented fitting code."""
-
-
-def _strip_fences(code: str) -> str:
-    """Strip markdown code fences from a code string."""
-    if "```" not in code:
-        return code
-    lines = code.splitlines()
-    code_lines = []
-    in_block = False
-    for line in lines:
-        if line.strip().startswith("```"):
-            in_block = not in_block
-            continue
-        if in_block:
-            code_lines.append(line)
-    return "\n".join(code_lines)
 
 
 class FittingAgent(BaseAgent):
@@ -131,7 +116,7 @@ class FittingAgent(BaseAgent):
                 MemoryKind.DOMAIN_PATTERNS,
             ),
         )
-        code = _strip_fences(code)
+        code = strip_fences(code)
 
         # Pre-exec convention check (Addition 3): check generated code for convention
         # violations before running it; retry once if violations are found.
@@ -176,7 +161,7 @@ class FittingAgent(BaseAgent):
                                 MemoryKind.DOMAIN_PATTERNS,
                             ),
                         )
-                        code = _strip_fences(code)
+                        code = strip_fences(code)
                 else:
                     break  # No violation — proceed to exec
 

--- a/mtf/agents/tool_builder.py
+++ b/mtf/agents/tool_builder.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 
 from mtf.agents.base import BaseAgent
 from mtf.memory import MemoryKind, SharedMemory
+from mtf.utils import strip_fences
 
 import numpy as np
 from lmfit import Model, Parameters, minimize
@@ -125,17 +126,7 @@ class ToolBuilderAgent(BaseAgent):
         )
 
         # Strip markdown fences if the model added them anyway
-        if "```" in code:
-            lines = code.splitlines()
-            code_lines: list[str] = []
-            in_block = False
-            for line in lines:
-                if line.strip().startswith("```"):
-                    in_block = not in_block
-                    continue
-                if in_block:
-                    code_lines.append(line)
-            code = "\n".join(code_lines)
+        code = strip_fences(code)
 
         data, models, err = _exec_digest_code(code)
 

--- a/mtf/utils.py
+++ b/mtf/utils.py
@@ -1,0 +1,24 @@
+"""Shared utility helpers for mtf."""
+
+from __future__ import annotations
+
+
+def strip_fences(code: str) -> str:
+    """Strip markdown code fences from a code string.
+
+    Handles single or multiple fenced blocks; returns only the content
+    that was inside the fences.  If no fences are present, returns *code*
+    unchanged.
+    """
+    if "```" not in code:
+        return code
+    lines = code.splitlines()
+    code_lines: list[str] = []
+    in_block = False
+    for line in lines:
+        if line.strip().startswith("```"):
+            in_block = not in_block
+            continue
+        if in_block:
+            code_lines.append(line)
+    return "\n".join(code_lines)


### PR DESCRIPTION
## Summary

- `fitting.py` defined a private `_strip_fences()` function
- `tool_builder.py` had a byte-for-byte identical inline copy (11 lines) that was not reusing the existing function
- Extract both into `mtf/utils.py` as the single canonical `strip_fences()` and import it in both call sites

## Why

Using an existing function instead of duplicating logic is the minimal-reinvention approach. Any future bug fix or improvement only needs to happen in one place.

## Review notes (addressed)

- Trailing newline drop (`splitlines()` + `join()` silently loses a trailing `\n`) — pre-existing in both originals, no regression introduced
- Prose before the first fence is silently dropped — pre-existing, documented in new docstring
- Unclosed fence collects all remaining lines — pre-existing degraded behaviour, acceptable
- `_strip_fences` → `strip_fences` (drop leading underscore) is correct for a shared utility

## Test plan

- [x] `python -c "from mtf.utils import strip_fences"` succeeds
- [x] `from mtf.agents.fitting import FittingAgent` succeeds
- [x] `from mtf.agents.tool_builder import ToolBuilderAgent` succeeds
- [ ] Existing tests pass: `pytest tests/test_memory.py tests/test_debate.py tests/test_phases.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)