### PR TITLE
Replace _looks_complex string triggers with stdlib compile()

### DIFF
--- a/mtf/phases/fitting_phase.py
+++ b/mtf/phases/fitting_phase.py
@@ -15,9 +15,18 @@ from mtf.toolkit.registry import ToolkitRegistry
 
 
 def _looks_complex(value: str) -> bool:
-    """Return True when the input is too rich for a plain eval()."""
-    triggers = ("\n", "def ", "class ", "import ", "->", "lambda ", "csv", "\t")
-    return any(t in value for t in triggers)
+    """Return True when the input is too rich for a plain eval().
+
+    Uses the stdlib compiler to check whether *value* is a valid single
+    expression.  If ``compile()`` with mode ``'eval'`` raises a
+    ``SyntaxError`` the string cannot be safely evaluated and the
+    ToolBuilderAgent slow path is needed.
+    """
+    try:
+        compile(value, "<string>", "eval")
+        return False
+    except SyntaxError:
+        return True
 
 
 async def _prefetch_fitting_warnings(


### PR DESCRIPTION
## Summary

- **Before:** `_looks_complex()` used a hardcoded tuple of trigger strings (`"\n"`, `"def "`, `"import "`, `"->"`, `"lambda "`, `"csv"`, `"\t"`) to decide whether user input needs the ToolBuilderAgent slow path vs a plain `eval()`
- **After:** Uses `compile(value, '<string>', 'eval')` — if it raises `SyntaxError`, the input is complex; otherwise it is a valid expression and takes the fast path

## Why this is better

| | Old approach | New approach |
|---|---|---|
| Accuracy | Heuristic — `[1,\n2,\n3]` falsely triggers the slow path | Exact — the Python compiler decides |
| Maintenance | Requires manually adding triggers as Python syntax evolves | Automatically correct for all syntax |
| Dependencies | None | None (stdlib `compile()`) |

## Behavior change: lambda expressions

`lambda x: x**2` previously matched the `"lambda "` trigger and went to the slow path (ToolBuilderAgent → `register_model`). It is now a valid `eval`-mode expression and goes to the fast path (`eval()` → `register_data`).

**This is accepted as intentional.** A lambda stored via `register_data` is still a callable the fitting agent can use. The correct long-term fix for the data/model bucket distinction is explicit user intent (a prompt asking whether the input is data or a model), not heuristic string matching.

## Review notes (addressed)

- `compile("", ..., "eval")` raises `SyntaxError` → `_looks_complex("")` returns `True`. Harmless in practice (caller already skips empty input)
- Single-line CSV-ish strings (e.g. `"1.0, 2.0, 3.0"`) now fast-path to a tuple; multi-line CSV still raises `SyntaxError` → slow path. Acceptable.
- The compiled code object is discarded rather than passed to `eval()` — minor inefficiency, kept simple for readability

## Test plan

- [x] `[1,2,3]`, `3.14`, `{'a': 1}` → fast path
- [x] `def f(): pass`, `import os`, `x = 1\ny = 2` → slow path
- [x] `lambda x: x` → fast path (intentional, see above)
- [ ] `pytest tests/test_phases.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)