### PR TITLE
Replace _blocking_get polling loop with queue.Queue.get(timeout=...)

### DIFF
--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -6,6 +6,7 @@ import asyncio
 import queue
 import tempfile
 import threading
+import time
 import traceback
 from pathlib import Path
 from typing import Any

--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -6,7 +6,6 @@ import asyncio
 import queue
 import tempfile
 import threading
-import time
 import traceback
 from pathlib import Path
 from typing import Any
@@ -17,20 +16,20 @@ from typing import Any
 
 from mtf.interface import HumanInterface
 
-_REPLY_POLL_INTERVAL = 1.0  # seconds between timeout checks in _blocking_get
-_REPLY_TIMEOUT = 3600.0     # 1 hour — abandon wait if browser tab was closed
+_REPLY_TIMEOUT = 3600.0  # 1 hour — abandon wait if browser tab was closed
 
 
 def _blocking_get(rq: "queue.Queue[Any]") -> Any:
-    """Poll *rq* in short intervals so the thread can eventually be GC'd if the
-    browser session disappears (avoids an indefinite daemon-thread leak)."""
-    deadline = time.monotonic() + _REPLY_TIMEOUT
-    while time.monotonic() < deadline:
-        try:
-            return rq.get(timeout=_REPLY_POLL_INTERVAL)
-        except queue.Empty:
-            continue
-    raise TimeoutError("No reply received from Streamlit within the timeout period.")
+    """Wait on *rq* for up to *_REPLY_TIMEOUT* seconds.
+
+    The orchestrator thread is a daemon thread, so it is automatically
+    killed when the main process exits.  A finite timeout is still set so
+    that a closed browser tab eventually releases the thread.
+    """
+    try:
+        return rq.get(timeout=_REPLY_TIMEOUT)
+    except queue.Empty:
+        raise TimeoutError("No reply received from Streamlit within the timeout period.")
 
 
 class StreamlitInterface(HumanInterface):


### PR DESCRIPTION
## Summary

- Removes a manual poll-in-a-loop in `_blocking_get()` that reimplemented what `queue.Queue.get(timeout=N)` already provides
- Restores `import time` (needed by `time.sleep(0.3)` in `_streamlit_app()` — bug caught in review)

## Detail

The old implementation polled `rq.get(timeout=1.0)` in a `while` loop up to `_REPLY_TIMEOUT` (3600 s), advancing a monotonic deadline on each iteration. This is exactly what `queue.Queue.get(timeout=3600)` does internally via `threading.Condition` with an absolute deadline.

The docstring justified the polling as preventing daemon-thread GC leaks. Python daemon threads are killed automatically when the main process exits — no polling checkpoint needed. The simplified version is functionally equivalent with fewer moving parts.

## Review notes (addressed)

- **Critical bug fixed:** initial commit accidentally removed `import time`, but `time.sleep(0.3)` at line 282 still uses it → `NameError` on every GUI run. Fixed in follow-up commit.
- Signal handling unaffected — signals go only to the main thread regardless
- GIL release unaffected — `condition.wait()` inside `queue.Queue.get()` releases the GIL identically to the old approach
- Timeout precision is actually slightly better: OS timer granularity vs. up to 1 s late with the old 1-second poll interval

## Test plan

- [ ] Start the Streamlit GUI, submit a phenomenon, verify the UI responds to user input normally
- [ ] Closing the browser tab eventually lets the background thread exit (within 1 h)
- [ ] `pytest tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)