### PR TITLE
Add post-report follow-up chat (FollowUpChatAgent)

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -295,7 +295,7 @@ Runs concurrently with `ReviewerAgent` instances inside the review phase. Propos
 |---|---|
 | **Phase** | ④ Follow-up Chat (post-report, optional) |
 | **API** | `sdk.query()` (agentic, no tools) |
-| **Memory context read** | `LITERATURE`, `DEBATE`, `HYPOTHESIS`, `FIT_RESULT`, `REVIEW`, `PROPOSALS`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS`, `QUALITATIVE_EVAL` |
+| **Memory context read** | `LITERATURE`, `DEBATE`, `HYPOTHESIS`, `FIT_RESULT`, `REVIEW`, `PROPOSALS`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS`, `QUALITATIVE_EVAL`, `DOMAIN_PATTERNS`, `FITTING_SKIPPED`, `TOOLKIT_DIGEST` |
 | **Memory written** | None |
 
 Created by `MTFOrchestrator._run_followup_chat()` after the final report is shown.  A single

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -289,6 +289,30 @@ Runs concurrently with `ReviewerAgent` instances inside the review phase. Propos
 
 ---
 
+## FollowUpChatAgent
+
+| | |
+|---|---|
+| **Phase** | ④ Follow-up Chat (post-report, optional) |
+| **API** | `sdk.query()` (agentic, no tools) |
+| **Memory context read** | `LITERATURE`, `DEBATE`, `HYPOTHESIS`, `FIT_RESULT`, `REVIEW`, `PROPOSALS`, `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS`, `QUALITATIVE_EVAL` |
+| **Memory written** | None |
+
+Created by `MTFOrchestrator._run_followup_chat()` after the final report is shown.  A single
+instance handles the entire Q&A session; no tools are provided because the full `SharedMemory`
+context already contains all analysis results.
+
+**Multi-turn memory:** `FollowUpChatAgent` maintains a local `_history` list.  Each `chat()`
+call prepends the accumulated `User: … / Assistant: …` dialogue to the task string before
+calling `_query()`, giving the agent conversational memory across turns despite `sdk.query()`
+being stateless per call.
+
+**Loop behaviour:** managed by the orchestrator — questions are read via `interface.ask()`,
+responses are displayed via `interface.show()`, and the loop exits on empty input or
+`exit` / `quit`.
+
+---
+
 ## ToolBuilderAgent
 
 | | |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -66,7 +66,8 @@ flowchart TD
         direction TB
         CQ{"Follow-up\nquestions?"}
         CA["FollowUpChatAgent\nfull memory context\nmulti-turn Q&A loop"]
-        CQ -->|"yes — loop until exit"| CA
+        CQ -->|"yes"| CA
+        CA -->|"next question"| CA
     end
 
     GPD -.->|"tools"| L

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,8 +1,8 @@
 # Architecture Overview
 
-MTF runs four sequential phases. Each phase fans out parallel agents, collects their reports,
-synthesises them in a single debate call, and (where applicable) waits for user approval before
-proceeding.
+MTF runs four analysis phases followed by an optional follow-up chat. Each analysis phase fans
+out parallel agents, collects their reports, synthesises them in a single debate call, and
+(where applicable) waits for user approval before proceeding.
 
 ## Pipeline
 
@@ -62,6 +62,13 @@ flowchart TD
         PD --> FR
     end
 
+    subgraph CHAT ["④ FOLLOW-UP CHAT (optional)"]
+        direction TB
+        CQ{"Follow-up\nquestions?"}
+        CA["FollowUpChatAgent\nfull memory context\nmulti-turn Q&A loop"]
+        CQ -->|"yes — loop until exit"| CA
+    end
+
     GPD -.->|"tools"| L
     GPD -.->|"tools"| F
     GPD -.->|"tools"| R
@@ -79,7 +86,9 @@ flowchart TD
     IMG --> LIT
     LIT -->|"approved hypotheses"| FIT
     FIT --> REV
-    REV --> Report
+    REV --> CQ
+    CQ -->|"no"| Report
+    CA -->|"exit"| Report
 ```
 
 ---
@@ -340,6 +349,34 @@ returned to the user.
 
 ---
 
+## Phase 4: Follow-up Chat
+
+After the final report is shown, `MTFOrchestrator._run_followup_chat()` offers an optional
+interactive Q&A session.
+
+1. **Opt-in gate:** the user is asked `"Would you like to ask follow-up questions?"`.
+   Declining skips the phase entirely; the orchestrator returns the final report string
+   unchanged.
+
+2. **Single agent:** one `FollowUpChatAgent` is created.  It has no tools — follow-up
+   questions are answered purely from the full `SharedMemory` context, which at this point
+   contains all `LITERATURE`, `DEBATE`, `HYPOTHESIS`, `FIT_RESULT`, `REVIEW`, `PROPOSALS`,
+   `USER_FEEDBACK`, `IMAGE_DATA`, `CONVENTIONS`, `PHYSICS_VERDICT`, `FITTING_WARNINGS`,
+   and `QUALITATIVE_EVAL` entries.
+
+3. **Multi-turn loop:** each question is sent to `sdk.query()` with the full memory context
+   prepended and the accumulated conversation history appended.  The history is formatted as
+   an alternating `User: … / Assistant: …` dialogue block and grows with each exchange, so
+   the agent can refer back to earlier answers.  The loop exits when the user submits an
+   empty line or types `exit` / `quit`.
+
+**Why a single agent (not a panel):** The reviewer and proposal agents already produced their
+specialised verdicts; those are stored in `SharedMemory` and injected into every follow-up
+prompt automatically.  A single agent answering from that rich context is faster and produces
+more coherent multi-turn replies than re-running a full fan-out + debate cycle per question.
+
+---
+
 ## Debate Engine internals
 
 `DebateEngine.synthesize()` is always a single plain `messages.create()` call — never an
@@ -414,7 +451,8 @@ mtf/
 │   ├── qualitative.py      QualitativeEvaluationAgent (--no-fitting mode)
 │   ├── reviewer.py         ReviewerAgent
 │   ├── proposal.py         ProposalAgent
-│   └── tool_builder.py     ToolBuilderAgent
+│   ├── tool_builder.py     ToolBuilderAgent
+│   └── followup.py         FollowUpChatAgent (post-report Q&A)
 ├── phases/
 │   ├── literature_phase.py convention lock + debate loop + approval gate
 │   ├── fitting_phase.py    toolkit resolution + fan-out + debate

--- a/mtf/agents/followup.py
+++ b/mtf/agents/followup.py
@@ -1,0 +1,67 @@
+"""Follow-up chat agent for post-report Q&A."""
+
+from __future__ import annotations
+
+from mtf.agents.base import BaseAgent
+from mtf.config import MTFConfig
+from mtf.memory import MemoryKind, SharedMemory
+
+_SYSTEM_PROMPT = """\
+You are a theoretical physics expert who has just completed a full multi-agent analysis \
+of an experimental phenomenon. You have access to the complete analysis: literature review, \
+candidate hypotheses, fitting results, reviewer verdicts, and proposed measurements.
+
+Answer follow-up questions clearly and precisely. Reference specific results, numbers, or \
+verdicts from the analysis where relevant. If the user asks about something outside the \
+scope of the analysis, say so honestly rather than speculating beyond what was established.
+"""
+
+# All memory kinds that are meaningful for follow-up context.
+_ALL_KINDS: tuple[MemoryKind, ...] = (
+    MemoryKind.LITERATURE,
+    MemoryKind.DEBATE,
+    MemoryKind.HYPOTHESIS,
+    MemoryKind.FIT_RESULT,
+    MemoryKind.REVIEW,
+    MemoryKind.PROPOSALS,
+    MemoryKind.USER_FEEDBACK,
+    MemoryKind.IMAGE_DATA,
+    MemoryKind.CONVENTIONS,
+    MemoryKind.PHYSICS_VERDICT,
+    MemoryKind.FITTING_WARNINGS,
+    MemoryKind.QUALITATIVE_EVAL,
+)
+
+
+class FollowUpChatAgent(BaseAgent):
+    """Single agent for post-report follow-up questions.
+
+    Maintains a local conversation history so that each new question is sent
+    together with the prior exchanges, giving the agent multi-turn memory even
+    though sdk.query() is stateless per call.
+    """
+
+    def __init__(self, config: MTFConfig, memory: SharedMemory) -> None:
+        super().__init__(
+            agent_id="followup",
+            model=config.model,
+            tools=[],
+            memory=memory,
+            system_prompt=_SYSTEM_PROMPT,
+        )
+        self._history: list[str] = []
+
+    async def chat(self, question: str) -> str:
+        """Send a follow-up question and return the agent's answer."""
+        # Build a multi-turn dialogue block from prior exchanges.
+        if self._history:
+            history_block = "\n\n".join(self._history)
+            task = f"{history_block}\n\nUser: {question}\nAssistant:"
+        else:
+            task = f"User: {question}\nAssistant:"
+
+        answer = await self._query(task, extra_kinds=_ALL_KINDS)
+
+        # Append this exchange so future calls include it.
+        self._history.append(f"User: {question}\nAssistant: {answer}")
+        return answer

--- a/mtf/agents/followup.py
+++ b/mtf/agents/followup.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from mtf.agents.base import BaseAgent
 from mtf.config import MTFConfig
 from mtf.memory import MemoryKind, SharedMemory
+from mtf.tools.gpd_mcp import GPDMCPClient
 
 _SYSTEM_PROMPT = """\
 You are a theoretical physics expert who has just completed a full multi-agent analysis \
@@ -30,21 +33,35 @@ _ALL_KINDS: tuple[MemoryKind, ...] = (
     MemoryKind.PHYSICS_VERDICT,
     MemoryKind.FITTING_WARNINGS,
     MemoryKind.QUALITATIVE_EVAL,
+    MemoryKind.DOMAIN_PATTERNS,
+    MemoryKind.FITTING_SKIPPED,
+    MemoryKind.TOOLKIT_DIGEST,
 )
+
+# Maximum number of past exchanges kept in the rolling history window.
+# Prevents unbounded context growth across long sessions.
+_MAX_HISTORY = 10
 
 
 class FollowUpChatAgent(BaseAgent):
     """Single agent for post-report follow-up questions.
 
-    Maintains a local conversation history so that each new question is sent
-    together with the prior exchanges, giving the agent multi-turn memory even
-    though sdk.query() is stateless per call.
+    Maintains a rolling conversation history (capped at _MAX_HISTORY exchanges)
+    so that each new question is sent together with recent prior exchanges,
+    giving the agent multi-turn memory even though sdk.query() is stateless
+    per call.
     """
 
-    def __init__(self, config: MTFConfig, memory: SharedMemory) -> None:
+    def __init__(
+        self,
+        config: MTFConfig,
+        memory: SharedMemory,
+        gpd_tools: list[Any] | None = None,
+        gpd: GPDMCPClient | None = None,
+    ) -> None:
         super().__init__(
             agent_id="followup",
-            model=config.model,
+            model=config.followup_model,
             tools=[],
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
@@ -53,7 +70,7 @@ class FollowUpChatAgent(BaseAgent):
 
     async def chat(self, question: str) -> str:
         """Send a follow-up question and return the agent's answer."""
-        # Build a multi-turn dialogue block from prior exchanges.
+        # Build a multi-turn dialogue block from the rolling history window.
         if self._history:
             history_block = "\n\n".join(self._history)
             task = f"{history_block}\n\nUser: {question}\nAssistant:"
@@ -62,6 +79,8 @@ class FollowUpChatAgent(BaseAgent):
 
         answer = await self._query(task, extra_kinds=_ALL_KINDS)
 
-        # Append this exchange so future calls include it.
+        # Append this exchange and enforce the rolling window cap.
         self._history.append(f"User: {question}\nAssistant: {answer}")
+        if len(self._history) > _MAX_HISTORY:
+            self._history = self._history[-_MAX_HISTORY:]
         return answer

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -52,6 +52,7 @@ class MTFConfig:
     # Proposal agent
     n_proposal: int = 2
     proposal_model: str = "claude-opus-4-6"
+    followup_model: str = "claude-opus-4-6"
 
     # PDF enhanced extraction
     pdf_enhanced_extraction: bool = True

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -6,6 +6,7 @@ import asyncio
 import re
 from pathlib import Path
 
+from mtf.agents.followup import FollowUpChatAgent
 from mtf.agents.image_digest import ImageDigestAgent
 from mtf.config import MTFConfig
 from mtf.debate import DebateEngine
@@ -199,8 +200,36 @@ class MTFOrchestrator:
                 gpd=gpd,
             )
 
+            await self._run_followup_chat()
+
         finally:
             if gpd is not None:
                 gpd.close()
 
         return final_report
+
+    async def _run_followup_chat(self) -> None:
+        """Interactive follow-up Q&A loop after the final report is shown.
+
+        Creates a single FollowUpChatAgent with full shared-memory context and
+        loops until the user submits an empty input or types 'exit' / 'quit'.
+        """
+        wants_chat = await self._interface.confirm(
+            "Would you like to ask follow-up questions about the analysis?"
+        )
+        if not wants_chat:
+            return
+
+        agent = FollowUpChatAgent(self._config, self._memory)
+        await self._interface.show(
+            "You can now ask follow-up questions about the analysis. "
+            "Type an empty line or **exit** to finish.",
+            title="MTF: Follow-up Chat",
+        )
+
+        while True:
+            question = await self._interface.ask("Your question")
+            if not question.strip() or question.strip().lower() in {"exit", "quit"}:
+                break
+            answer = await agent.chat(question.strip())
+            await self._interface.show(answer, title="MTF: Follow-up")

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -200,11 +200,13 @@ class MTFOrchestrator:
                 gpd=gpd,
             )
 
-            await self._run_followup_chat()
-
         finally:
             if gpd is not None:
                 gpd.close()
+
+        # Follow-up chat runs outside the try/finally block so that a chat error
+        # cannot mask a successfully completed run or interfere with GPD cleanup.
+        await self._run_followup_chat()
 
         return final_report
 
@@ -213,11 +215,16 @@ class MTFOrchestrator:
 
         Creates a single FollowUpChatAgent with full shared-memory context and
         loops until the user submits an empty input or types 'exit' / 'quit'.
+        API errors on individual questions are caught and displayed rather than
+        propagated, so a transient failure cannot abort the session.
         """
         wants_chat = await self._interface.confirm(
             "Would you like to ask follow-up questions about the analysis?"
         )
         if not wants_chat:
+            await self._interface.show(
+                "Follow-up chat skipped.", title="MTF: Follow-up Chat"
+            )
             return
 
         agent = FollowUpChatAgent(self._config, self._memory)
@@ -231,5 +238,12 @@ class MTFOrchestrator:
             question = await self._interface.ask("Your question")
             if not question.strip() or question.strip().lower() in {"exit", "quit"}:
                 break
-            answer = await agent.chat(question.strip())
+            try:
+                answer = await agent.chat(question.strip())
+            except Exception as exc:  # noqa: BLE001
+                await self._interface.show(
+                    f"Error getting answer: {exc}\n\nPlease try again.",
+                    title="MTF: Follow-up Chat",
+                )
+                continue
             await self._interface.show(answer, title="MTF: Follow-up")

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1,0 +1,191 @@
+"""Tests for FollowUpChatAgent and _run_followup_chat orchestrator method."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mtf.agents.followup import FollowUpChatAgent, _MAX_HISTORY
+from mtf.config import MTFConfig
+from mtf.interface import HumanInterface
+from mtf.memory import MemoryKind, SharedMemory
+from mtf.orchestrator import MTFOrchestrator
+
+
+class MockInterface(HumanInterface):
+    def __init__(self, confirm_value: bool = True, ask_values: list[str] | None = None):
+        self._confirm = confirm_value
+        self._ask_values = list(ask_values or [])
+        self._ask_index = 0
+
+    async def show(self, content: str, title: str = "") -> None:
+        pass
+
+    async def ask(self, prompt: str) -> str:
+        if self._ask_index < len(self._ask_values):
+            val = self._ask_values[self._ask_index]
+            self._ask_index += 1
+            return val
+        return ""
+
+    async def confirm(self, prompt: str) -> bool:
+        return self._confirm
+
+
+# ---------------------------------------------------------------------------
+# FollowUpChatAgent construction
+# ---------------------------------------------------------------------------
+
+def test_followup_agent_construction():
+    """FollowUpChatAgent should construct without error using config.followup_model."""
+    config = MTFConfig()
+    memory = SharedMemory()
+    agent = FollowUpChatAgent(config, memory)
+    assert agent._agent_id == "followup"
+    assert agent._model == config.followup_model
+
+
+def test_followup_agent_accepts_gpd_params():
+    """Constructor should accept gpd_tools and gpd without error (forward-compat)."""
+    config = MTFConfig()
+    memory = SharedMemory()
+    agent = FollowUpChatAgent(config, memory, gpd_tools=[], gpd=None)
+    assert agent is not None
+
+
+# ---------------------------------------------------------------------------
+# History management
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_history_accumulates():
+    """chat() should append each exchange to _history."""
+    config = MTFConfig()
+    memory = SharedMemory()
+    agent = FollowUpChatAgent(config, memory)
+
+    with patch.object(agent, "_query", new=AsyncMock(return_value="answer")):
+        await agent.chat("question 1")
+        await agent.chat("question 2")
+
+    assert len(agent._history) == 2
+    assert "question 1" in agent._history[0]
+    assert "question 2" in agent._history[1]
+
+
+@pytest.mark.asyncio
+async def test_history_rolling_window():
+    """History should not exceed _MAX_HISTORY entries."""
+    config = MTFConfig()
+    memory = SharedMemory()
+    agent = FollowUpChatAgent(config, memory)
+
+    with patch.object(agent, "_query", new=AsyncMock(return_value="ans")):
+        for i in range(_MAX_HISTORY + 5):
+            await agent.chat(f"q{i}")
+
+    assert len(agent._history) == _MAX_HISTORY
+
+
+@pytest.mark.asyncio
+async def test_history_prepended_to_subsequent_query():
+    """Second call should include the first exchange in the task string."""
+    config = MTFConfig()
+    memory = SharedMemory()
+    agent = FollowUpChatAgent(config, memory)
+
+    calls: list[str] = []
+
+    async def capture_query(task, extra_kinds=()):
+        calls.append(task)
+        return "answer"
+
+    with patch.object(agent, "_query", new=capture_query):
+        await agent.chat("first question")
+        await agent.chat("second question")
+
+    # First call: no history prefix
+    assert calls[0].startswith("User: first question")
+    # Second call: contains the first exchange
+    assert "first question" in calls[1]
+    assert "second question" in calls[1]
+
+
+# ---------------------------------------------------------------------------
+# _run_followup_chat orchestrator method
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_followup_chat_skipped_when_declined():
+    """Declining the confirm prompt should skip the loop entirely."""
+    config = MTFConfig()
+    interface = MockInterface(confirm_value=False)
+    orc = MTFOrchestrator(config=config, interface=interface)
+
+    # Should complete without calling sdk.query
+    with patch("mtf.agents.followup.FollowUpChatAgent.chat") as mock_chat:
+        await orc._run_followup_chat()
+        mock_chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_followup_chat_exits_on_empty_input():
+    """Empty input should exit the loop after one iteration."""
+    config = MTFConfig()
+    interface = MockInterface(confirm_value=True, ask_values=[""])
+    orc = MTFOrchestrator(config=config, interface=interface)
+
+    with patch("mtf.agents.followup.FollowUpChatAgent.chat") as mock_chat:
+        await orc._run_followup_chat()
+        mock_chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_followup_chat_exits_on_quit_keyword():
+    """'quit' input should exit the loop."""
+    config = MTFConfig()
+    interface = MockInterface(confirm_value=True, ask_values=["quit"])
+    orc = MTFOrchestrator(config=config, interface=interface)
+
+    with patch("mtf.agents.followup.FollowUpChatAgent.chat") as mock_chat:
+        await orc._run_followup_chat()
+        mock_chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_followup_chat_handles_api_error_gracefully():
+    """An API error on one question should not abort the loop."""
+    config = MTFConfig()
+    # First ask raises, second ask exits
+    interface = MockInterface(confirm_value=True, ask_values=["bad question", ""])
+    orc = MTFOrchestrator(config=config, interface=interface)
+
+    with patch(
+        "mtf.orchestrator.FollowUpChatAgent.chat",
+        new=AsyncMock(side_effect=RuntimeError("API failure")),
+    ):
+        # Should not raise; loop exits cleanly on the empty second input
+        await orc._run_followup_chat()
+
+
+@pytest.mark.asyncio
+async def test_followup_chat_calls_agent_and_shows_answer():
+    """A valid question should invoke chat() and display the answer."""
+    config = MTFConfig()
+    shown: list[str] = []
+
+    class CapturingInterface(MockInterface):
+        async def show(self, content: str, title: str = "") -> None:
+            shown.append(content)
+
+    interface = CapturingInterface(confirm_value=True, ask_values=["what is the best fit?", ""])
+    orc = MTFOrchestrator(config=config, interface=interface)
+
+    with patch(
+        "mtf.orchestrator.FollowUpChatAgent.chat",
+        new=AsyncMock(return_value="The best fit is model A."),
+    ):
+        await orc._run_followup_chat()
+
+    assert any("The best fit is model A." in s for s in shown)


### PR DESCRIPTION
## Summary

- Adds `mtf/agents/followup.py` — `FollowUpChatAgent` that wraps `BaseAgent` with no tools, injects all `SharedMemory` kinds into every query, and accumulates a local conversation history for multi-turn coherence
- Adds `MTFOrchestrator._run_followup_chat()` — opt-in Q&A loop (confirm gate, ask loop, show response) called at the end of `run()` before GPD cleanup
- Updates `docs/architecture/overview.md`: mermaid pipeline diagram extended with a FOLLOW-UP CHAT subgraph; new Phase 4 prose section; file layout updated
- Updates `docs/architecture/agents.md`: new FollowUpChatAgent section with metadata table and multi-turn memory explanation

## Design decisions

- **Single agent, not panel**: reviewer/proposal verdicts are already in SharedMemory and injected into every prompt — no need to re-run the fan-out and debate cycle per question
- **History in task string**: sdk.query() is stateless per call; prior exchanges are prepended as a User/Assistant block so the agent has conversational memory
- **No new MemoryKind**: follow-up exchanges are ephemeral to the session and do not need to survive to future phases or runs

## Test plan

- [ ] Run `pytest tests/test_memory.py tests/test_debate.py tests/test_phases.py` — all pass (MockInterface.confirm returns False by default, skipping the chat loop)
- [ ] Manual smoke test: run `mtf "some phenomenon"`, reach final report, answer y to follow-up prompt, ask a question, verify answer references analysis results, type exit to quit
- [ ] Verify empty-input exit path works (press Enter at question prompt)

Generated with [Claude Code](https://claude.com/claude-code)
