### PR TITLE
feat: hierarchical memory index, PHENOMENON anchoring, and honesty enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ python examples/run_experiment.py
 Results are stored as `MemoryKind.IMAGE_DATA`. If more than one file is supplied, a synthesis call produces a cross-file unified analysis (stored as a separate `IMAGE_DATA` entry). All agent types include `IMAGE_DATA` in `extra_kinds` so extracted data is visible in every prompt context.
 
 ### Shared Memory
-`SharedMemory` is a plain Python object passed by reference to every phase and agent. It is safe under asyncio's single-threaded event loop — no locks needed. `BaseAgent._build_prompt()` prepends a formatted context block before every `sdk.query()` call so agents always see prior debate summaries and user feedback.
+`SharedMemory` is a plain Python object passed by reference to every phase and agent. It is safe under asyncio's single-threaded event loop — no locks needed. `BaseAgent._build_prompt()` prepends a formatted context block before every `sdk.query()` call so agents always see prior debate summaries and user feedback. `format_index()` returns a compact one-line-per-entry table of contents. `format_context()` prepends this index automatically when more than 3 entries are present, giving agents a navigable structure. `MemoryKind.PHENOMENON` is written at orchestrator start so every agent always sees the original question.
 
 ### Debate Mechanism
 Each phase: fan-out agents with `asyncio.gather()` → collect reports → `DebateEngine.synthesize()` (one `messages.create()` call, not agentic) → store result as `MemoryKind.DEBATE` → present to user → optional feedback → approval gate → repeat up to `config.max_debate_rounds`.
@@ -183,3 +183,5 @@ Install with `pip install -e ".[dev,gpd]"`. Controlled by `config.enable_gpd_mcp
 - `ImageDigestAgent` uses `messages.create()` (not sdk.query()) — keep it that way; it needs multimodal content blocks that the agent-sdk does not expose.
 - `DebateEngine.synthesize()` is a plain API call, not an agent loop — keep it that way for speed.
 - `run_fitting_code()` uses `exec()` intentionally; do not replace with subprocess or a sandbox service without user approval.
+- `BaseAgent._build_prompt()` always appends a honesty-enforcement reminder and, when CONVENTIONS entries exist, a convention-lock reminder. Never remove these.
+- `MemoryKind.PHENOMENON` is written once at `MTFOrchestrator.run()` start and is never overwritten.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ python examples/run_experiment.py
 Results are stored as `MemoryKind.IMAGE_DATA`. If more than one file is supplied, a synthesis call produces a cross-file unified analysis (stored as a separate `IMAGE_DATA` entry). All agent types include `IMAGE_DATA` in `extra_kinds` so extracted data is visible in every prompt context.
 
 ### Shared Memory
-`SharedMemory` is a plain Python object passed by reference to every phase and agent. It is safe under asyncio's single-threaded event loop — no locks needed. `BaseAgent._build_prompt()` prepends a formatted context block before every `sdk.query()` call so agents always see prior debate summaries and user feedback. `format_index()` returns a compact one-line-per-entry table of contents. `format_context()` prepends this index automatically when more than 3 entries are present, giving agents a navigable structure. `MemoryKind.PHENOMENON` is written at orchestrator start so every agent always sees the original question.
+`SharedMemory` is a plain Python object passed by reference to every phase and agent. It is safe under asyncio's single-threaded event loop — no locks needed. `BaseAgent._build_prompt()` prepends a formatted context block before every `sdk.query()` call so agents always see prior debate summaries and user feedback. `_format_index(entries)` is a private helper that produces a compact one-line-per-entry table of contents using `--- INDEX ---` / `--- FULL ENTRIES BELOW ---` delimiters and 80-char previews. `format_context()` calls `_format_index()` automatically when more than 3 entries are present, giving agents a navigable structure. The public `format_index()` is a thin wrapper that calls `_format_index(self._entries)`. `MemoryKind.PHENOMENON` is written once at orchestrator start (guarded against double-write on re-entrant calls) so every agent always sees the original question.
 
 ### Debate Mechanism
 Each phase: fan-out agents with `asyncio.gather()` → collect reports → `DebateEngine.synthesize()` (one `messages.create()` call, not agentic) → store result as `MemoryKind.DEBATE` → present to user → optional feedback → approval gate → repeat up to `config.max_debate_rounds`.
@@ -183,5 +183,5 @@ Install with `pip install -e ".[dev,gpd]"`. Controlled by `config.enable_gpd_mcp
 - `ImageDigestAgent` uses `messages.create()` (not sdk.query()) — keep it that way; it needs multimodal content blocks that the agent-sdk does not expose.
 - `DebateEngine.synthesize()` is a plain API call, not an agent loop — keep it that way for speed.
 - `run_fitting_code()` uses `exec()` intentionally; do not replace with subprocess or a sandbox service without user approval.
-- `BaseAgent._build_prompt()` always appends a honesty-enforcement reminder and, when CONVENTIONS entries exist, a convention-lock reminder. Never remove these.
-- `MemoryKind.PHENOMENON` is written once at `MTFOrchestrator.run()` start and is never overwritten.
+- `BaseAgent._build_prompt()` always appends a honesty-enforcement reminder (unconditional, not configurable) and, when CONVENTIONS entries exist, a convention-lock reminder. Never remove these.
+- `MemoryKind.PHENOMENON` is written at most once per `MTFOrchestrator` instance; `run()` guards against double-write with a `filter()` check.

--- a/mtf/agents/base.py
+++ b/mtf/agents/base.py
@@ -8,6 +8,19 @@ import claude_agent_sdk as sdk
 
 from mtf.memory import MemoryKind, SharedMemory
 
+_HONESTY_REMINDER = (
+    "\n\nVERIFICATION STANDARD: Do NOT use phrases like 'this becomes', "
+    "'for consistency', or 'as expected' to skip showing your reasoning. "
+    "Do not claim to have verified something unless you explicitly performed "
+    "the check in this response. If uncertain, say so explicitly."
+)
+
+_CONVENTION_REMINDER = (
+    "\n\nCONVENTION LOCK: The physics conventions shown in the context above are "
+    "LOCKED for this run. Do not revert to textbook defaults (different metric "
+    "signature, Fourier convention, unit system, or gauge choice)."
+)
+
 
 class BaseAgent:
     """Wraps sdk.query() and injects shared memory context into every prompt."""
@@ -28,9 +41,13 @@ class BaseAgent:
 
     def _build_prompt(self, task: str, extra_kinds: tuple[MemoryKind, ...] = ()) -> str:
         ctx = self._memory.format_context(*extra_kinds)
+        has_conventions = bool(self._memory.filter(MemoryKind.CONVENTIONS))
+        suffix = _HONESTY_REMINDER
+        if has_conventions:
+            suffix += _CONVENTION_REMINDER
         if ctx:
-            return f"{ctx}\n\nTask: {task}"
-        return task
+            return f"{ctx}\n\nTask: {task}{suffix}"
+        return task + suffix
 
     async def _query(self, task: str, extra_kinds: tuple[MemoryKind, ...] = ()) -> str:
         prompt = self._build_prompt(task, extra_kinds)

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -9,6 +9,7 @@ class MTFConfig:
 
     # Agent counts
     n_literature: int = 2
+    citation_verification: bool = True  # require LiteratureAgent to re-verify each citation
     n_fitting: int = 2
     n_qualitative: int = 2
     n_reviewer: int = 2
@@ -58,3 +59,7 @@ class MTFConfig:
     pdf_enhanced_extraction: bool = True
     pdf_figure_extraction_max_tokens: int = 8192
     pdf_min_size_kb_for_enhanced: int = 200
+
+    # Honesty and memory structure (vibe-physics lessons)
+    honesty_enforcement: bool = True  # inject honesty reminder into every agent prompt
+    memory_index: bool = True         # prepend navigable index to context when >3 entries

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -60,6 +60,3 @@ class MTFConfig:
     pdf_figure_extraction_max_tokens: int = 8192
     pdf_min_size_kb_for_enhanced: int = 200
 
-    # Honesty and memory structure (vibe-physics lessons)
-    honesty_enforcement: bool = True  # inject honesty reminder into every agent prompt
-    memory_index: bool = True         # prepend navigable index to context when >3 entries

--- a/mtf/memory.py
+++ b/mtf/memory.py
@@ -52,19 +52,26 @@ class SharedMemory:
             return list(self._entries)
         return [e for e in self._entries if e.kind in kinds]
 
-    def format_index(self) -> str:
-        """Return a compact one-line-per-entry table of contents for the context."""
-        entries = self._entries
+    def _format_index(self, entries: list[MemoryEntry]) -> str:
+        """Private helper: return a compact one-line-per-entry index for a list of entries.
+
+        Uses 80-char previews and ``--- INDEX ---`` / ``--- FULL ENTRIES BELOW ---``
+        delimiters so the output integrates cleanly into ``format_context()``.
+        """
         if not entries:
             return ""
-        lines = ["=== CONTEXT INDEX ==="]
+        lines = ["--- INDEX ---"]
         for i, e in enumerate(entries):
-            preview = e.content[:100].replace("\n", " ")
+            preview = e.content[:80].replace("\n", " ")
             agent = e.metadata.get("agent_id", e.metadata.get("source", ""))
-            tag = f"{e.kind.value.upper()}" + (f"/{agent}" if agent else "")
+            tag = e.kind.value.upper() + (f"/{agent}" if agent else "")
             lines.append(f"[{i+1}] [{tag}] {preview}...")
-        lines.append("=== END INDEX ===")
+        lines.append("--- FULL ENTRIES BELOW ---")
         return "\n".join(lines)
+
+    def format_index(self) -> str:
+        """Return a compact one-line-per-entry table of contents for all entries."""
+        return self._format_index(self._entries)
 
     def format_context(self, *kinds: MemoryKind) -> str:
         entries = self.filter(*kinds) if kinds else self._entries
@@ -73,14 +80,7 @@ class SharedMemory:
         lines = ["=== SHARED CONTEXT ==="]
         # Prepend index for navigability when context is large
         if len(entries) > 3:
-            index_lines = ["--- INDEX ---"]
-            for i, e in enumerate(entries):
-                preview = e.content[:80].replace("\n", " ")
-                agent = e.metadata.get("agent_id", e.metadata.get("source", ""))
-                tag = e.kind.value.upper() + (f"/{agent}" if agent else "")
-                index_lines.append(f"[{i+1}] [{tag}] {preview}...")
-            index_lines.append("--- FULL ENTRIES BELOW ---")
-            lines.extend(index_lines)
+            lines.append(self._format_index(entries))
         for e in entries:
             lines.append(f"[{e.kind.value.upper()}] {e.content}")
         lines.append("=== END CONTEXT ===")

--- a/mtf/memory.py
+++ b/mtf/memory.py
@@ -25,6 +25,7 @@ class MemoryKind(str, Enum):
     QUALITATIVE_EVAL = "qualitative_eval"  # qualitative hypothesis evaluation (used when fitting is skipped)
     FITTING_SKIPPED = "fitting_skipped"    # marker written when --no-fitting is active
     PROPOSALS = "proposals"
+    PHENOMENON = "phenomenon"      # original user phenomenon anchored at run start
 
 
 @dataclass
@@ -51,11 +52,35 @@ class SharedMemory:
             return list(self._entries)
         return [e for e in self._entries if e.kind in kinds]
 
+    def format_index(self) -> str:
+        """Return a compact one-line-per-entry table of contents for the context."""
+        entries = self._entries
+        if not entries:
+            return ""
+        lines = ["=== CONTEXT INDEX ==="]
+        for i, e in enumerate(entries):
+            preview = e.content[:100].replace("\n", " ")
+            agent = e.metadata.get("agent_id", e.metadata.get("source", ""))
+            tag = f"{e.kind.value.upper()}" + (f"/{agent}" if agent else "")
+            lines.append(f"[{i+1}] [{tag}] {preview}...")
+        lines.append("=== END INDEX ===")
+        return "\n".join(lines)
+
     def format_context(self, *kinds: MemoryKind) -> str:
         entries = self.filter(*kinds) if kinds else self._entries
         if not entries:
             return ""
         lines = ["=== SHARED CONTEXT ==="]
+        # Prepend index for navigability when context is large
+        if len(entries) > 3:
+            index_lines = ["--- INDEX ---"]
+            for i, e in enumerate(entries):
+                preview = e.content[:80].replace("\n", " ")
+                agent = e.metadata.get("agent_id", e.metadata.get("source", ""))
+                tag = e.kind.value.upper() + (f"/{agent}" if agent else "")
+                index_lines.append(f"[{i+1}] [{tag}] {preview}...")
+            index_lines.append("--- FULL ENTRIES BELOW ---")
+            lines.extend(index_lines)
         for e in entries:
             lines.append(f"[{e.kind.value.upper()}] {e.content}")
         lines.append("=== END CONTEXT ===")

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -111,8 +111,10 @@ class MTFOrchestrator:
             Final report as a string.
         """
         gpd = GPDMCPClient() if self._config.enable_gpd_mcp else None
-        # Anchor the original phenomenon in memory so all agents can always reference it
-        self._memory.add(MemoryKind.PHENOMENON, phenomenon)
+        # Anchor the original phenomenon in memory so all agents can always reference it.
+        # Guard against double-write if run() is called more than once on the same instance.
+        if not self._memory.filter(MemoryKind.PHENOMENON):
+            self._memory.add(MemoryKind.PHENOMENON, phenomenon)
         if gpd is not None:
             gpd.start(self._config.gpd_servers)
 

--- a/mtf/orchestrator.py
+++ b/mtf/orchestrator.py
@@ -111,6 +111,8 @@ class MTFOrchestrator:
             Final report as a string.
         """
         gpd = GPDMCPClient() if self._config.enable_gpd_mcp else None
+        # Anchor the original phenomenon in memory so all agents can always reference it
+        self._memory.add(MemoryKind.PHENOMENON, phenomenon)
         if gpd is not None:
             gpd.start(self._config.gpd_servers)
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -72,8 +72,8 @@ def test_format_index_with_entries():
     m.add(MemoryKind.LITERATURE, "Superconductivity reference", agent_id="lit-0")
     m.add(MemoryKind.DEBATE, "Consensus: BCS most likely")
     index = m.format_index()
-    assert "=== CONTEXT INDEX ===" in index
-    assert "=== END INDEX ===" in index
+    assert "--- INDEX ---" in index
+    assert "--- FULL ENTRIES BELOW ---" in index
     assert "[1]" in index
     assert "[2]" in index
     assert "[3]" in index

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -59,3 +59,51 @@ def test_metadata_stored():
     m.add(MemoryKind.LITERATURE, "content", agent_id="lit-0")
     entry = m.filter(MemoryKind.LITERATURE)[0]
     assert entry.metadata["agent_id"] == "lit-0"
+
+
+def test_format_index_empty():
+    m = SharedMemory()
+    assert m.format_index() == ""
+
+
+def test_format_index_with_entries():
+    m = SharedMemory()
+    m.add(MemoryKind.PHENOMENON, "Anomalous resistance drop at 4K")
+    m.add(MemoryKind.LITERATURE, "Superconductivity reference", agent_id="lit-0")
+    m.add(MemoryKind.DEBATE, "Consensus: BCS most likely")
+    index = m.format_index()
+    assert "=== CONTEXT INDEX ===" in index
+    assert "=== END INDEX ===" in index
+    assert "[1]" in index
+    assert "[2]" in index
+    assert "[3]" in index
+    assert "PHENOMENON" in index
+    assert "LITERATURE/lit-0" in index
+    assert "DEBATE" in index
+
+
+def test_format_context_prepends_index_when_more_than_3_entries():
+    m = SharedMemory()
+    for i in range(4):
+        m.add(MemoryKind.LITERATURE, f"paper {i}")
+    ctx = m.format_context()
+    assert "--- INDEX ---" in ctx
+    assert "--- FULL ENTRIES BELOW ---" in ctx
+    # All full entries still present (index has 4 + full entries have 4 = 8 total occurrences)
+    assert ctx.count("[LITERATURE]") == 8
+
+
+def test_format_context_no_index_for_3_or_fewer_entries():
+    m = SharedMemory()
+    for i in range(3):
+        m.add(MemoryKind.LITERATURE, f"paper {i}")
+    ctx = m.format_context()
+    assert "--- INDEX ---" not in ctx
+
+
+def test_phenomenon_kind_exists():
+    m = SharedMemory()
+    m.add(MemoryKind.PHENOMENON, "Strange metallic state at low T")
+    entries = m.filter(MemoryKind.PHENOMENON)
+    assert len(entries) == 1
+    assert entries[0].content == "Strange metallic state at low T"


### PR DESCRIPTION
## Summary
- Adds navigable index header to SharedMemory.format_context() when >3 entries via unified _format_index() helper
- Adds MemoryKind.PHENOMENON written once at run start (guarded against double-write)
- Adds global honesty enforcement and convention-lock reminders in BaseAgent._build_prompt() — always-on, not configurable

## Motivation
From Schwartz's vibe-physics paper: agents work better with hierarchical structures; Claude reverts to textbook conventions under pressure; Claude claims 'verified' without checking.

## Merge order
**Merge this first.** PR #20 depends on this branch.

🤖 Generated with Claude Code