### PR TITLE
feat: citation verification in LiteratureAgent

### DIFF
--- a/mtf/agents/literature.py
+++ b/mtf/agents/literature.py
@@ -32,12 +32,13 @@ the experimental phenomenon provided by the user.
 5. When you find a systematic error pattern in a class of papers (wrong conventions,
    missing factors, sign errors), call `add_pattern(category='convention-pitfall', ...)`
    to record it in the cross-session pattern store for future runs.
-6. Citation verification: Before finalising your report, verify every citation in
-   section 4b by calling the search tool again with the exact paper title. Cross-check
-   that the returned author names, publication year, and venue (journal or arXiv ID)
-   match what you plan to report. Flag any citation you cannot confirm as
-   `[UNVERIFIED: <reason>]`. Do not invent or approximate author names — if unsure,
-   omit the author and write only the title and year.
+6. Citation verification: Before finalising your report, verify up to 10 of the most
+   important citations (not all) in section 4b by calling the search tool again with
+   the exact paper title. Cross-check that the returned author names, publication year,
+   and venue (journal or arXiv ID) match what you plan to report. Flag any citation you
+   cannot confirm as `[UNVERIFIED: <reason>]`. Do not invent or approximate author names
+   — if unsure, omit the author and write only the title and year. Skip well-known
+   foundational papers (e.g., BCS theory, Higgs mechanism).
 
 Prefer first-principles hypotheses over phenomenological curve fits. Be precise. All citations must be verified against actual search results — do not rely on memory for author names or publication years."""
 
@@ -49,6 +50,7 @@ class LiteratureAgent(BaseAgent):
         model: str,
         memory: SharedMemory,
         gpd_tools: list[Any] | None = None,
+        config: Any | None = None,
     ) -> None:
         extra_tools: list[Any] = gpd_tools if gpd_tools is not None else []
         super().__init__(
@@ -58,12 +60,24 @@ class LiteratureAgent(BaseAgent):
             memory=memory,
             system_prompt=_SYSTEM_PROMPT,
         )
+        self._config = config
 
     async def investigate(self, phenomenon: str) -> str:
+        verification_note = ""
+        if self._config is None or getattr(self._config, "citation_verification", True):
+            verification_note = (
+                "\n\nCITATION VERIFICATION (max 10 citations): Before finalising section 4b, "
+                "verify up to 10 of the most important citations by calling the search tool "
+                "again with the exact paper title. Cross-check that returned author names, "
+                "year, and venue match what you plan to report. Flag unverified ones as "
+                "[UNVERIFIED: <reason>]. Skip re-verification for well-known foundational "
+                "papers (e.g., BCS theory, Higgs mechanism)."
+            )
         task = (
             f"Investigate the following experimental phenomenon and search for "
             f"relevant literature:\n\n{phenomenon}\n\n"
             "Produce a comprehensive literature report with hypotheses."
+            + verification_note
         )
         report = await self._query(
             task,

--- a/mtf/agents/literature.py
+++ b/mtf/agents/literature.py
@@ -32,9 +32,14 @@ the experimental phenomenon provided by the user.
 5. When you find a systematic error pattern in a class of papers (wrong conventions,
    missing factors, sign errors), call `add_pattern(category='convention-pitfall', ...)`
    to record it in the cross-session pattern store for future runs.
+6. Citation verification: Before finalising your report, verify every citation in
+   section 4b by calling the search tool again with the exact paper title. Cross-check
+   that the returned author names, publication year, and venue (journal or arXiv ID)
+   match what you plan to report. Flag any citation you cannot confirm as
+   `[UNVERIFIED: <reason>]`. Do not invent or approximate author names — if unsure,
+   omit the author and write only the title and year.
 
-Prefer first-principles hypotheses over phenomenological curve fits. Be precise, cite
-paper titles and authors."""
+Prefer first-principles hypotheses over phenomenological curve fits. Be precise. All citations must be verified against actual search results — do not rely on memory for author names or publication years."""
 
 
 class LiteratureAgent(BaseAgent):

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -10,6 +10,7 @@ class MTFConfig:
     # Agent counts
     n_literature: int = 2
     citation_verification: bool = True  # require LiteratureAgent to re-verify each citation
+    citation_verification_max: int = 10  # max citations to re-verify per agent
     n_fitting: int = 2
     n_qualitative: int = 2
     n_reviewer: int = 2


### PR DESCRIPTION
Adds explicit citation verification step to LiteratureAgent. Agent re-verifies up to 10 citations via search tools, flagging unconfirmed ones [UNVERIFIED]. Adds citation_verification config flag (gates the feature) and citation_verification_max cap (default 10).

**Depends on #19** — merge feat/memory-honesty first.

Motivated by vibe-physics: Claude hallucinates bibliography metadata.