### PR TITLE
feat: reviewer second-pass loop and multi-model diversity

### DIFF
--- a/mtf/agents/reviewer.py
+++ b/mtf/agents/reviewer.py
@@ -48,7 +48,14 @@ If `[FITTING_SKIPPED]` appears in your context, the fitting phase was skipped an
 - Do not rank by chi² — rank by: (1) physics check results on theoretical arguments,
   (2) parsimony, (3) first-principles basis.
 - Your recommendation should focus on what data collection would be needed to upgrade
-  qualitative assessments to quantitative fits."""
+  qualitative assessments to quantitative fits.
+
+EXHAUSTIVE REVIEW REQUIREMENT: After completing steps 1-9 above, re-read your \
+entire review from the start. Do NOT stop after identifying the most prominent problem. \
+Enumerate ALL issues found, including minor concerns, under an \
+'Additional concerns:' section at the end of your report. A review that identifies \
+three issues is more valuable than one that stops at the first. Only conclude when \
+you have nothing new to add."""
 
 
 class ReviewerAgent(BaseAgent):

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -14,6 +14,8 @@ class MTFConfig:
     n_fitting: int = 2
     n_qualitative: int = 2
     n_reviewer: int = 2
+    reviewer_verification_passes: int = 1  # >1 enables structural "check again" loop
+    reviewer_models: list[str] = field(default_factory=list)  # cycles models for diversity
 
     # Model selection
     literature_model: str = "claude-haiku-4-5-20251001"
@@ -53,9 +55,6 @@ class MTFConfig:
     fitting_result_integrity_check: bool = True  # detect hardcoded/fabricated fit results
 
     # Proposal agent
-    reviewer_verification_passes: int = 1  # >1 enables structural "check again" loop
-    reviewer_models: list[str] = field(default_factory=list)  # cycles models for diversity
-
     n_proposal: int = 2
     proposal_model: str = "claude-sonnet-4-6"
     followup_model: str = "claude-sonnet-4-6"

--- a/mtf/config.py
+++ b/mtf/config.py
@@ -53,6 +53,9 @@ class MTFConfig:
     fitting_result_integrity_check: bool = True  # detect hardcoded/fabricated fit results
 
     # Proposal agent
+    reviewer_verification_passes: int = 1  # >1 enables structural "check again" loop
+    reviewer_models: list[str] = field(default_factory=list)  # cycles models for diversity
+
     n_proposal: int = 2
     proposal_model: str = "claude-sonnet-4-6"
     followup_model: str = "claude-sonnet-4-6"

--- a/mtf/phases/review_phase.py
+++ b/mtf/phases/review_phase.py
@@ -84,10 +84,16 @@ async def run_review_phase(
         title="MTF: Review",
     )
 
+    def _reviewer_model(i: int) -> str:
+        models = getattr(config, "reviewer_models", [])
+        if models:
+            return models[i % len(models)]
+        return config.reviewer_model
+
     agents = [
         ReviewerAgent(
             agent_id=f"rev-{i}",
-            model=config.reviewer_model,
+            model=_reviewer_model(i),
             memory=memory,
             gpd_tools=gpd_tools,
         )
@@ -110,6 +116,45 @@ async def run_review_phase(
     )
     reviewer_reports = list(all_results[:config.n_reviewer])
     proposal_reports = list(all_results[config.n_reviewer:])
+
+    # Second-pass verification loop (vibe-physics: "repeat Check again until nothing new")
+    if getattr(config, "reviewer_verification_passes", 1) > 1:
+        await interface.show(
+            f"Running {config.reviewer_verification_passes - 1} additional verification pass(es)...",
+            title="MTF: Review",
+        )
+        for pass_num in range(config.reviewer_verification_passes - 1):
+            second_pass_tasks = [
+                (
+                    f"Original phenomenon:\n{phenomenon}\n\n"
+                    f"Your previous review:\n{report}\n\n"
+                    f"Re-read the above review from the beginning. Did you miss anything? "
+                    f"Check every claim, equation, parameter range, and citation again. "
+                    f"Append additional findings under 'Additional concerns (pass {pass_num + 2}):'. "
+                    f"If you found nothing new, state that explicitly."
+                )
+                for report in reviewer_reports
+            ]
+            second_pass_reports = await asyncio.gather(
+                *(
+                    agent._query(
+                        task,
+                        extra_kinds=(
+                            MemoryKind.LITERATURE,
+                            MemoryKind.DEBATE,
+                            MemoryKind.FIT_RESULT,
+                            MemoryKind.USER_FEEDBACK,
+                            MemoryKind.IMAGE_DATA,
+                            MemoryKind.CONVENTIONS,
+                            MemoryKind.PHYSICS_VERDICT,
+                            MemoryKind.QUALITATIVE_EVAL,
+                            MemoryKind.FITTING_SKIPPED,
+                        ),
+                    )
+                    for agent, task in zip(agents, second_pass_tasks)
+                )
+            )
+            reviewer_reports = list(second_pass_reports)
 
     review_synthesis = await debate_engine.synthesize(
         reviewer_reports,

--- a/mtf/phases/review_phase.py
+++ b/mtf/phases/review_phase.py
@@ -85,7 +85,7 @@ async def run_review_phase(
     )
 
     def _reviewer_model(i: int) -> str:
-        models = getattr(config, "reviewer_models", [])
+        models = config.reviewer_models
         if models:
             return models[i % len(models)]
         return config.reviewer_model
@@ -118,7 +118,7 @@ async def run_review_phase(
     proposal_reports = list(all_results[config.n_reviewer:])
 
     # Second-pass verification loop (vibe-physics: "repeat Check again until nothing new")
-    if getattr(config, "reviewer_verification_passes", 1) > 1:
+    if config.reviewer_verification_passes > 1:
         await interface.show(
             f"Running {config.reviewer_verification_passes - 1} additional verification pass(es)...",
             title="MTF: Review",
@@ -130,7 +130,7 @@ async def run_review_phase(
                     f"Your previous review:\n{report}\n\n"
                     f"Re-read the above review from the beginning. Did you miss anything? "
                     f"Check every claim, equation, parameter range, and citation again. "
-                    f"Append additional findings under 'Additional concerns (pass {pass_num + 2}):'. "
+                    f"Append additional findings under 'Additional concerns:'. "
                     f"If you found nothing new, state that explicitly."
                 )
                 for report in reviewer_reports

--- a/tests/test_review_phase.py
+++ b/tests/test_review_phase.py
@@ -1,0 +1,69 @@
+"""Tests for review phase second-pass loop and multi-model cycling."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mtf.config import MTFConfig
+from mtf.memory import SharedMemory
+
+
+def test_reviewer_model_cycling():
+    """reviewer_models cycles correctly across reviewer instances."""
+    from mtf.phases.review_phase import run_review_phase  # noqa: PLC0415
+
+    config = MTFConfig(
+        n_reviewer=3,
+        reviewer_models=["model-a", "model-b"],
+    )
+    # Extract the cycling logic inline (mirrors _reviewer_model inner function)
+    def _reviewer_model(i: int) -> str:
+        models = config.reviewer_models
+        if models:
+            return models[i % len(models)]
+        return config.reviewer_model
+
+    assert _reviewer_model(0) == "model-a"
+    assert _reviewer_model(1) == "model-b"
+    assert _reviewer_model(2) == "model-a"  # wraps
+
+
+def test_reviewer_model_fallback():
+    """Empty reviewer_models falls back to reviewer_model."""
+    config = MTFConfig(reviewer_models=[], reviewer_model="claude-sonnet-4-6")
+
+    def _reviewer_model(i: int) -> str:
+        models = config.reviewer_models
+        if models:
+            return models[i % len(models)]
+        return config.reviewer_model
+
+    assert _reviewer_model(0) == "claude-sonnet-4-6"
+    assert _reviewer_model(5) == "claude-sonnet-4-6"
+
+
+def test_reviewer_verification_passes_default():
+    """Default reviewer_verification_passes is 1 (no second pass)."""
+    config = MTFConfig()
+    assert config.reviewer_verification_passes == 1
+
+
+def test_reviewer_verification_passes_second_pass_task_contains_first_report():
+    """Second-pass task text must include the first-pass report."""
+    first_report = "First pass review: hypothesis A is SUPPORTED."
+    phenomenon = "Anomalous resistance peak at 4K"
+    pass_num = 0
+
+    task = (
+        f"Original phenomenon:\n{phenomenon}\n\n"
+        f"Your previous review:\n{first_report}\n\n"
+        f"Re-read the above review from the beginning. Did you miss anything? "
+        f"Check every claim, equation, parameter range, and citation again. "
+        f"Append additional findings under 'Additional concerns:'. "
+        f"If you found nothing new, state that explicitly."
+    )
+    assert first_report in task
+    assert phenomenon in task
+    assert "Additional concerns:" in task


### PR DESCRIPTION
## Summary
- Adds exhaustive review requirement to ReviewerAgent system prompt
- Adds structural second-pass verification loop: reviewer_verification_passes > 1 triggers re-check
- Adds multi-model cycling via reviewer_models config field
- Config fields placed next to n_reviewer; direct attribute access (no getattr)
- Adds 4 unit tests

## Motivation
From Schwartz's vibe-physics paper: Claude stops after finding first error; different models catch different errors.

## Merge order
Independent of #21 and #23. Merge after #19/#20. Conflicts on reviewer.py if merged after #21 (both touch it) — resolve by keeping both changes.

🤖 Generated with Claude Code