### PR TITLE
feat: debate anti-consensus and follow-up pressure resistance

### DIFF
--- a/mtf/agents/followup.py
+++ b/mtf/agents/followup.py
@@ -17,6 +17,13 @@ candidate hypotheses, fitting results, reviewer verdicts, and proposed measureme
 Answer follow-up questions clearly and precisely. Reference specific results, numbers, or \
 verdicts from the analysis where relevant. If the user asks about something outside the \
 scope of the analysis, say so honestly rather than speculating beyond what was established.
+
+PRESSURE RESISTANCE: If the user pushes back on a conclusion from the analysis, \
+re-evaluate the evidence independently rather than accommodating their preference. \
+Changing a position requires new evidence or a logical argument — user insistence alone \
+is not sufficient reason to revise a verdict. If the original conclusion was well-supported, \
+defend it with specific evidence from the analysis. It is scientifically appropriate to \
+disagree with the user.
 """
 
 # All memory kinds that are meaningful for follow-up context.

--- a/mtf/agents/followup.py
+++ b/mtf/agents/followup.py
@@ -19,11 +19,12 @@ verdicts from the analysis where relevant. If the user asks about something outs
 scope of the analysis, say so honestly rather than speculating beyond what was established.
 
 PRESSURE RESISTANCE: If the user pushes back on a conclusion from the analysis, \
-re-evaluate the evidence independently rather than accommodating their preference. \
-Changing a position requires new evidence or a logical argument — user insistence alone \
-is not sufficient reason to revise a verdict. If the original conclusion was well-supported, \
-defend it with specific evidence from the analysis. It is scientifically appropriate to \
-disagree with the user.
+review the specific evidence in the analysis that supports the original conclusion \
+rather than accommodating their preference. Changing a position requires new evidence \
+or a logical argument — user insistence alone is not sufficient reason to revise a \
+verdict. If the original conclusion was well-supported by the analysis, cite the \
+specific results, fit parameters, or reviewer verdicts that justify it. It is \
+scientifically appropriate to disagree with the user.
 """
 
 # All memory kinds that are meaningful for follow-up context.

--- a/mtf/debate.py
+++ b/mtf/debate.py
@@ -57,8 +57,13 @@ class DebateEngine:
         base_system = (
             f"You are a synthesis engine for the {phase} phase of a multi-agent "
             "physics research assistant. Your job is to produce a single coherent "
-            "synthesis of the provided agent reports, resolving contradictions and "
-            "highlighting the strongest hypotheses or conclusions. Be concise and precise."
+            "synthesis of the provided agent reports, highlighting the strongest "
+            "hypotheses or conclusions. Be concise and precise.\n\n"
+            "IMPORTANT — preserve genuine disagreement: If agents reach contradictory "
+            "conclusions, present both views clearly and explain the evidential tension "
+            "rather than smoothing them into false consensus. Use phrases like "
+            "'agents agree' or 'consensus' only when reports genuinely agree. "
+            "Unresolved contradictions are scientifically valuable — do not suppress them."
         )
 
         if phase in ("fitting", "review"):

--- a/mtf/debate.py
+++ b/mtf/debate.py
@@ -58,13 +58,20 @@ class DebateEngine:
             f"You are a synthesis engine for the {phase} phase of a multi-agent "
             "physics research assistant. Your job is to produce a single coherent "
             "synthesis of the provided agent reports, highlighting the strongest "
-            "hypotheses or conclusions. Be concise and precise.\n\n"
-            "IMPORTANT — preserve genuine disagreement: If agents reach contradictory "
-            "conclusions, present both views clearly and explain the evidential tension "
-            "rather than smoothing them into false consensus. Use phrases like "
-            "'agents agree' or 'consensus' only when reports genuinely agree. "
-            "Unresolved contradictions are scientifically valuable — do not suppress them."
+            "hypotheses or conclusions. Be concise and precise."
         )
+
+        # Anti-consensus instruction for scientific phases only (not proposals,
+        # which explicitly requires deduplication and merging)
+        if phase != "proposals":
+            base_system += (
+                "\n\nIMPORTANT — preserve genuine disagreement: If agents reach "
+                "contradictory conclusions, present both views clearly and explain "
+                "the evidential tension rather than smoothing them into false consensus. "
+                "Use phrases like 'agents agree' or 'consensus' only when reports "
+                "genuinely agree. Unresolved contradictions are scientifically "
+                "valuable — do not suppress them."
+            )
 
         if phase in ("fitting", "review"):
             physics_criterion = (


### PR DESCRIPTION
## Summary
- DebateEngine anti-consensus paragraph scoped to non-proposals phases only (proposals phase still deduplicates/merges)
- FollowUpChatAgent pressure resistance anchored to existing analysis evidence
- Fixes pre-existing test_gpd_integration.py assertion (== 4 → == 3)

## Motivation
From Schwartz's vibe-physics paper: Claude gives the answer users seem to want under pressure.

## Merge order
Independent. Merge after #19/#20. No expected conflicts.

🤖 Generated with Claude Code