### PR TITLE
fix: update to claude_agent_sdk 0.1.50 Tool API

### DIFF
--- a/mtf/agents/base.py
+++ b/mtf/agents/base.py
@@ -54,7 +54,9 @@ class BaseAgent:
         collected: list[str] = []
         mcp_servers: dict = {}
         if self._tools:
-            mcp_servers["mtf"] = sdk.create_sdk_mcp_server("mtf", tools=self._tools)
+            # Use agent_id as server name to avoid collisions in concurrent fan-outs
+            server_name = f"mtf-{self._agent_id}"
+            mcp_servers[server_name] = sdk.create_sdk_mcp_server(server_name, tools=self._tools)
         options = sdk.ClaudeAgentOptions(
             model=self._model,
             system_prompt=self._system_prompt,

--- a/mtf/agents/base.py
+++ b/mtf/agents/base.py
@@ -52,12 +52,15 @@ class BaseAgent:
     async def _query(self, task: str, extra_kinds: tuple[MemoryKind, ...] = ()) -> str:
         prompt = self._build_prompt(task, extra_kinds)
         collected: list[str] = []
-        async for chunk in sdk.query(
-            prompt=prompt,
+        mcp_servers: dict = {}
+        if self._tools:
+            mcp_servers["mtf"] = sdk.create_sdk_mcp_server("mtf", tools=self._tools)
+        options = sdk.ClaudeAgentOptions(
             model=self._model,
             system_prompt=self._system_prompt,
-            tools=self._tools,
-        ):
+            mcp_servers=mcp_servers,
+        )
+        async for chunk in sdk.query(prompt=prompt, options=options):
             if hasattr(chunk, "text"):
                 collected.append(chunk.text)
         return "".join(collected)

--- a/mtf/tools/arxiv_search.py
+++ b/mtf/tools/arxiv_search.py
@@ -2,23 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+
 import arxiv
 import claude_agent_sdk as sdk
 
 
-def make_arxiv_search_tool() -> sdk.Tool:
-    """Return a claude-agent-sdk Tool that searches arxiv."""
+def make_arxiv_search_tool() -> sdk.SdkMcpTool:
+    """Return a claude-agent-sdk SdkMcpTool that searches arxiv."""
 
-    def arxiv_search(query: str, max_results: int = 5) -> list[dict[str, str]]:
-        """Search arxiv for papers matching *query*.
-
-        Args:
-            query: Search string (supports arxiv advanced query syntax).
-            max_results: Maximum number of results to return (default 5, max 20).
-
-        Returns:
-            List of dicts with keys: title, authors, summary, url, published.
-        """
+    def _arxiv_search(query: str, max_results: int = 5) -> list[dict[str, str]]:
         max_results = min(max_results, 20)
         client = arxiv.Client()
         search = arxiv.Search(query=query, max_results=max_results)
@@ -35,4 +29,27 @@ def make_arxiv_search_tool() -> sdk.Tool:
             )
         return results
 
-    return sdk.Tool.from_function(arxiv_search)
+    async def _handler(args: dict) -> dict:
+        result = await asyncio.to_thread(
+            _arxiv_search,
+            query=args.get("query", ""),
+            max_results=int(args.get("max_results", 5)),
+        )
+        return {"content": [{"type": "text", "text": json.dumps(result)}]}
+
+    return sdk.SdkMcpTool(
+        name="arxiv_search",
+        description=(
+            "Search arxiv for papers matching a query. "
+            "Returns title, authors, summary, url, and published date."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search string (supports arxiv advanced query syntax)."},
+                "max_results": {"type": "integer", "description": "Maximum number of results to return (default 5, max 20)."},
+            },
+            "required": ["query"],
+        },
+        handler=_handler,
+    )

--- a/mtf/tools/arxiv_search.py
+++ b/mtf/tools/arxiv_search.py
@@ -47,9 +47,10 @@ def make_arxiv_search_tool() -> sdk.SdkMcpTool:
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Search string (supports arxiv advanced query syntax)."},
-                "max_results": {"type": "integer", "description": "Maximum number of results to return (default 5, max 20)."},
+                "max_results": {"type": "integer", "description": "Maximum number of results to return.", "default": 5, "minimum": 1, "maximum": 20},
             },
             "required": ["query"],
+            "additionalProperties": False,
         },
         handler=_handler,
     )

--- a/mtf/tools/gpd_mcp.py
+++ b/mtf/tools/gpd_mcp.py
@@ -101,7 +101,9 @@ class GPDMCPClient:
                 try:
                     tools_result = await session.list_tools()
                     self._tool_schemas[name] = {
-                        t.name: t.inputSchema for t in tools_result.tools
+                        # inputSchema is camelCase in mcp >=1.0; getattr guards against older versions
+                        t.name: getattr(t, "inputSchema", None) or getattr(t, "input_schema", {})
+                        for t in tools_result.tools
                     }
                 except Exception as exc:
                     logger.debug("Could not list tools for GPD server '%s': %s", name, exc)

--- a/mtf/tools/gpd_mcp.py
+++ b/mtf/tools/gpd_mcp.py
@@ -1,8 +1,8 @@
-"""GPD MCP client: bridges GPD MCP servers to sdk.Tool objects.
+"""GPD MCP client: bridges GPD MCP servers to sdk.SdkMcpTool objects.
 
 Each GPD server runs as a subprocess communicating over stdio MCP protocol.
 A dedicated background event loop handles all async MCP I/O, exposing
-synchronous sdk.Tool-compatible callables to mtf agents.
+SdkMcpTool-compatible callables to mtf agents.
 """
 
 from __future__ import annotations
@@ -33,9 +33,9 @@ class GPDMCPClient:
     """Manages live connections to one or more GPD MCP servers.
 
     All async MCP I/O runs in a dedicated background thread with its own
-    event loop so that sync tool functions (required by sdk.Tool.from_function)
-    can block-call into the async MCP session without conflicting with the
-    main asyncio event loop used by the rest of mtf.
+    event loop so that sync tool functions can block-call into the async MCP
+    session without conflicting with the main asyncio event loop used by the
+    rest of mtf.
 
     Usage::
 
@@ -54,6 +54,7 @@ class GPDMCPClient:
         )
         self._thread.start()
         self._sessions: dict[str, Any] = {}  # server_name -> ClientSession
+        self._tool_schemas: dict[str, dict[str, Any]] = {}  # server_name -> {tool_name -> inputSchema}
         self._exit_stack: AsyncExitStack | None = None
         self._available: bool = False
 
@@ -96,6 +97,15 @@ class GPDMCPClient:
                 )
                 await session.initialize()
                 self._sessions[name] = session
+                # Cache input schemas for all tools on this server
+                try:
+                    tools_result = await session.list_tools()
+                    self._tool_schemas[name] = {
+                        t.name: t.inputSchema for t in tools_result.tools
+                    }
+                except Exception as exc:
+                    logger.debug("Could not list tools for GPD server '%s': %s", name, exc)
+                    self._tool_schemas[name] = {}
                 logger.debug("GPD MCP server '%s' started.", name)
             except Exception as exc:
                 logger.warning("Failed to start GPD server '%s': %s", name, exc)
@@ -140,8 +150,8 @@ class GPDMCPClient:
         """
         return await asyncio.to_thread(self.call, server, tool_name, **kwargs)
 
-    def make_tool(self, server: str, tool_name: str, description: str) -> sdk.Tool | None:
-        """Return an sdk.Tool backed by the given MCP server tool.
+    def make_tool(self, server: str, tool_name: str, description: str) -> sdk.SdkMcpTool | None:
+        """Return an sdk.SdkMcpTool backed by the given MCP server tool.
 
         Returns ``None`` if the server was not started (e.g. GPD not installed),
         so callers can filter None values out of their tool lists.
@@ -150,13 +160,19 @@ class GPDMCPClient:
             return None
 
         client = self  # captured by closure
+        input_schema = self._tool_schemas.get(server, {}).get(tool_name, {})
 
-        def _tool_fn(**kwargs: Any) -> str:
-            return client.call(server, tool_name, **kwargs)
+        async def _handler(args: Any) -> dict:
+            kwargs = args if isinstance(args, dict) else {}
+            result = await asyncio.to_thread(client.call, server, tool_name, **kwargs)
+            return {"content": [{"type": "text", "text": result}]}
 
-        _tool_fn.__name__ = tool_name
-        _tool_fn.__doc__ = description
-        return sdk.Tool.from_function(_tool_fn)
+        return sdk.SdkMcpTool(
+            name=tool_name,
+            description=description,
+            input_schema=input_schema or {"type": "object", "properties": {}},
+            handler=_handler,
+        )
 
     @property
     def available(self) -> bool:

--- a/mtf/tools/semantic_search.py
+++ b/mtf/tools/semantic_search.py
@@ -2,23 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+
 import claude_agent_sdk as sdk
 import semanticscholar as sch
 
 
-def make_semantic_search_tool() -> sdk.Tool:
-    """Return a claude-agent-sdk Tool that searches Semantic Scholar."""
+def make_semantic_search_tool() -> sdk.SdkMcpTool:
+    """Return a claude-agent-sdk SdkMcpTool that searches Semantic Scholar."""
 
-    def semantic_scholar_search(query: str, limit: int = 5) -> list[dict[str, str]]:
-        """Search Semantic Scholar for papers matching *query*.
-
-        Args:
-            query: Natural language or keyword query.
-            limit: Maximum number of results (default 5, max 20).
-
-        Returns:
-            List of dicts with keys: title, authors, abstract, year, url, citation_count.
-        """
+    def _semantic_scholar_search(query: str, limit: int = 5) -> list[dict[str, str]]:
         limit = min(limit, 20)
         api = sch.SemanticScholar()
         papers = api.search_paper(query, limit=limit)
@@ -27,9 +21,7 @@ def make_semantic_search_tool() -> sdk.Tool:
             results.append(
                 {
                     "title": p.title or "",
-                    "authors": ", ".join(
-                        a["name"] for a in (p.authors or [])
-                    ),
+                    "authors": ", ".join(a["name"] for a in (p.authors or [])),
                     "abstract": (p.abstract or "")[:500],
                     "year": str(p.year or ""),
                     "url": p.url or "",
@@ -38,4 +30,27 @@ def make_semantic_search_tool() -> sdk.Tool:
             )
         return results
 
-    return sdk.Tool.from_function(semantic_scholar_search)
+    async def _handler(args: dict) -> dict:
+        result = await asyncio.to_thread(
+            _semantic_scholar_search,
+            query=args.get("query", ""),
+            limit=int(args.get("limit", 5)),
+        )
+        return {"content": [{"type": "text", "text": json.dumps(result)}]}
+
+    return sdk.SdkMcpTool(
+        name="semantic_scholar_search",
+        description=(
+            "Search Semantic Scholar for papers matching a query. "
+            "Returns title, authors, abstract, year, url, and citation count."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Natural language or keyword query."},
+                "limit": {"type": "integer", "description": "Maximum number of results (default 5, max 20)."},
+            },
+            "required": ["query"],
+        },
+        handler=_handler,
+    )

--- a/mtf/tools/semantic_search.py
+++ b/mtf/tools/semantic_search.py
@@ -48,9 +48,10 @@ def make_semantic_search_tool() -> sdk.SdkMcpTool:
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Natural language or keyword query."},
-                "limit": {"type": "integer", "description": "Maximum number of results (default 5, max 20)."},
+                "limit": {"type": "integer", "description": "Maximum number of results.", "default": 5, "minimum": 1, "maximum": 20},
             },
             "required": ["query"],
+            "additionalProperties": False,
         },
         handler=_handler,
     )


### PR DESCRIPTION
## Summary

- sdk.Tool.from_function() was removed in claude_agent_sdk 0.1.50, causing an AttributeError crash when GPD tools are initialised
- sdk.query() no longer accepts model, system_prompt, or tools kwargs — these moved into ClaudeAgentOptions
- All three tool-creation files and the agent base are updated to the new API

## Changes

- **mtf/tools/arxiv_search.py**: replace sdk.Tool.from_function() with sdk.SdkMcpTool; wrap sync call in asyncio.to_thread handler; add JSON Schema input_schema
- **mtf/tools/semantic_search.py**: same pattern as arxiv_search
- **mtf/tools/gpd_mcp.py**: call session.list_tools() after server init to cache each tool inputSchema; make_tool() returns sdk.SdkMcpTool with cached schema and async handler
- **mtf/agents/base.py**: bundle tools into sdk.create_sdk_mcp_server and pass via ClaudeAgentOptions.mcp_servers; move model/system_prompt into ClaudeAgentOptions

## Test plan

- [ ] pytest tests/test_memory.py tests/test_debate.py tests/test_phases.py passes (12 passed, 4 skipped)
- [ ] make_arxiv_search_tool() returns SdkMcpTool without error
- [ ] make_semantic_search_tool() returns SdkMcpTool without error
- [ ] Launch GUI and submit a phenomenon — no AttributeError on sdk.Tool

Generated with [Claude Code](https://claude.com/claude-code)