### PR TITLE
fix: pass human-readable report strings to fitting debate engine

### DIFF
--- a/mtf/agents/fitting.py
+++ b/mtf/agents/fitting.py
@@ -97,7 +97,7 @@ class FittingAgent(BaseAgent):
         lines = [line.strip() for line in response.splitlines() if line.strip()]
         return lines
 
-    async def fit(self, hypothesis: str) -> dict[str, object]:
+    async def fit(self, hypothesis: str) -> str:
         """Generate and execute fitting code for this hypothesis."""
         task = (
             f"Hypothesis:\n{hypothesis}\n\n"
@@ -192,4 +192,4 @@ class FittingAgent(BaseAgent):
             agent_id=self._agent_id,
             hypothesis=hypothesis,
         )
-        return fit_output
+        return report

--- a/mtf/phases/fitting_phase.py
+++ b/mtf/phases/fitting_phase.py
@@ -154,7 +154,7 @@ async def run_fitting_phase(
                 "when your fitting code fails to converge or produces unphysical parameters."),
         ] if t is not None]
 
-    async def fit_with_semaphore(agent: FittingAgent, hypothesis: str) -> dict[str, object]:
+    async def fit_with_semaphore(agent: FittingAgent, hypothesis: str) -> str:
         async with semaphore:
             return await agent.fit(hypothesis)
 
@@ -254,8 +254,7 @@ async def run_fitting_phase(
             results = await asyncio.gather(
                 *(fit_with_semaphore(a, hyp) for a in agents)
             )
-            reports = [str(r) for r in results]
-            all_fit_reports.extend(reports)
+            all_fit_reports.extend(results)
     else:
         agents = [
             FittingAgent(
@@ -272,7 +271,7 @@ async def run_fitting_phase(
         results = await asyncio.gather(
             *(fit_with_semaphore(a, hyp) for hyp in hypotheses for a in agents)
         )
-        all_fit_reports = [str(r) for r in results]
+        all_fit_reports = list(results)
 
     # Run phase-level physics checks before synthesis so PHYSICS_VERDICT is populated (Addition 2)
     await _run_phase_physics_checks(

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -101,3 +101,80 @@ async def test_literature_phase_loops_on_rejection(memory, config, mock_debate):
     assert call_count == 2
     feedback_entries = memory.filter(MemoryKind.USER_FEEDBACK)
     assert len(feedback_entries) >= 1
+
+
+@pytest.mark.asyncio
+async def test_fitting_phase_passes_string_reports_to_debate(memory, config, mock_debate):
+    """Regression test: debate engine must receive str reports, not dict reprs."""
+    from mtf.phases.fitting_phase import run_fitting_phase
+    from mtf.toolkit.registry import ToolkitRegistry
+
+    captured_reports: list[list[str]] = []
+
+    async def capture_synthesize(reports, **kwargs):
+        captured_reports.append(list(reports))
+        return "Fitting synthesis: quantum tunneling fits well"
+
+    mock_debate.synthesize = capture_synthesize
+
+    fit_report = "Hypothesis: quantum tunneling\n\nFit output: {'chi_squared': 1.2}"
+
+    with patch("mtf.phases.fitting_phase.FittingAgent") as MockAgent:
+        instance = AsyncMock()
+        instance.identify_needed_toolkit_items = AsyncMock(return_value=[])
+        instance.fit = AsyncMock(return_value=fit_report)
+        MockAgent.return_value = instance
+
+        interface = MockInterface(confirm_value=True)
+        await run_fitting_phase(
+            hypotheses=["quantum tunneling hypothesis"],
+            config=config,
+            memory=memory,
+            interface=interface,
+            debate_engine=mock_debate,
+            toolkit=ToolkitRegistry(),
+        )
+
+    assert len(captured_reports) == 1
+    reports = captured_reports[0]
+    assert all(isinstance(r, str) for r in reports), (
+        f"Debate engine received non-string reports: {[type(r) for r in reports]}"
+    )
+    assert any("Hypothesis" in r for r in reports), (
+        "Reports should contain the formatted hypothesis text, not a raw dict repr"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fitting_phase_stores_fit_results_in_memory(memory, config, mock_debate):
+    """FIT_RESULT memory entries should be populated after the fitting fan-out."""
+    from mtf.phases.fitting_phase import run_fitting_phase
+    from mtf.toolkit.registry import ToolkitRegistry
+
+    mock_debate.synthesize = AsyncMock(return_value="Synthesis")
+
+    fit_report = "Hypothesis: superconductivity\n\nFit output: {'chi_squared': 0.9}"
+
+    with patch("mtf.phases.fitting_phase.FittingAgent") as MockAgent:
+        instance = AsyncMock()
+        instance.identify_needed_toolkit_items = AsyncMock(return_value=[])
+        instance.fit = AsyncMock(return_value=fit_report)
+        MockAgent.return_value = instance
+
+        await run_fitting_phase(
+            hypotheses=["superconductivity hypothesis"],
+            config=config,
+            memory=memory,
+            interface=MockInterface(confirm_value=True),
+            debate_engine=mock_debate,
+            toolkit=ToolkitRegistry(),
+        )
+
+    fit_entries = memory.filter(MemoryKind.FIT_RESULT)
+    assert len(fit_entries) == 0, (
+        "FIT_RESULT entries are written by FittingAgent.fit() itself; "
+        "the mocked agent does not write them, so memory should be empty here"
+    )
+    # The synthesis is stored as DEBATE
+    debate_entries = memory.filter(MemoryKind.DEBATE)
+    assert len(debate_entries) == 1


### PR DESCRIPTION
## Summary

- `FittingAgent.fit()` was building a formatted `report` string (`"Hypothesis: ...\n\nFit output: ..."`) and storing it in memory as `FIT_RESULT`, but **returning the raw `fit_output` dict** instead
- `fitting_phase.py` called `str()` on each returned dict, producing Python reprs with embedded code strings (e.g. `{'result': None, 'code': 'import numpy as np\n...'}`) passed to the debate engine
- The debate engine synthesized from this noisy, unreadable input — causing the fitting synthesis panel to appear empty or meaningless to the user

Fix: change `fit()` to `return report` (the already-constructed human-readable string), update the return type annotation from `dict[str, object]` to `str`, and drop the `str(r)` conversion in both fan-out paths in `fitting_phase.py`.

## Test plan

- [x] `pytest tests/` — 32 passed, 34 skipped (pre-existing skips, no regressions)
- [x] `mypy mtf/agents/fitting.py mtf/phases/fitting_phase.py` — no errors in changed files
- [ ] Manual: run a fitting phase end-to-end and verify the synthesis panel shows readable content

🤖 Generated with [Claude Code](https://claude.com/claude-code)