### PR TITLE
fix: disable auto-detect domains by default, expose toggle in GUI

### DIFF
--- a/mtf/config.py
+++ b/mtf/config.py
@@ -44,7 +44,7 @@ class MTFConfig:
         default_factory=lambda: ["verification", "errors", "protocols", "conventions", "patterns", "skills"]
     )
     # Auto domain classification (Addition 1)
-    auto_detect_domains: bool = True
+    auto_detect_domains: bool = False
     gpd_domain_detection_max_domains: int = 3
     # Literature plausibility screen (Addition 5)
     literature_plausibility_screen: bool = True

--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -152,6 +152,11 @@ def _streamlit_app() -> None:
             index=0,
         )
         enable_gpd = st.checkbox("Enable GPD physics verification", value=True)
+        auto_detect_domains = st.checkbox(
+            "Auto-detect physics domains",
+            value=False,
+            help="Use GPD route_protocol/route_skill to infer physics domains from the phenomenon text. Off by default — set domains manually above.",
+        )
         enhanced_pdf = st.checkbox("Enhanced PDF extraction (2-pass figure analysis)", value=True)
 
         st.divider()
@@ -201,6 +206,7 @@ def _streamlit_app() -> None:
                 max_debate_rounds=max_debate_rounds,
                 physics_domains=physics_domains or ["condensed_matter"],
                 enable_gpd_mcp=enable_gpd,
+                auto_detect_domains=auto_detect_domains,
                 fitting_enabled=not skip_fitting,
                 reviewer_model=reviewer_model,
                 proposal_model=proposal_model,

--- a/tests/test_gpd_integration.py
+++ b/tests/test_gpd_integration.py
@@ -331,7 +331,7 @@ def test_config_defaults():
     assert cfg.gpd_servers == [
         "verification", "errors", "protocols", "conventions", "patterns", "skills"
     ]
-    assert cfg.auto_detect_domains is True
+    assert cfg.auto_detect_domains is False
     assert cfg.gpd_domain_detection_max_domains == 3
     assert cfg.literature_plausibility_screen is True
     assert cfg.auto_reject_physics_failures is False


### PR DESCRIPTION
## Summary

- `auto_detect_domains` default changed `True` → `False` in `MTFConfig` — users now control domain selection explicitly via the multiselect
- Added an opt-in "Auto-detect physics domains" checkbox in the GUI sidebar (next to the GPD toggle), wired into `MTFConfig`
- Updated the `test_config_defaults` assertion to match the new default

## Motivation

The current auto-detection uses substring matching against freeform `route_protocol`/`route_skill` responses from GPD, which is unreliable. A wrong domain silently causes incorrect convention locking, checklist selection, and fitting checks. Keeping it opt-in until the classification approach is improved prevents silent misbehaviour.

## Test plan

- [ ] `pytest tests/test_gpd_integration.py::test_config_defaults` passes
- [ ] GUI sidebar shows "Auto-detect physics domains" checkbox, unchecked by default
- [ ] With checkbox unchecked, `config.auto_detect_domains` is `False` and `_classify_domains` is skipped
- [ ] Checking the box enables auto-detection as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)