### PR TITLE
docs: fix stale auto_detect_domains defaults and add CLI flag entry

### DIFF
--- a/docs/architecture/gpd.md
+++ b/docs/architecture/gpd.md
@@ -28,8 +28,8 @@ For fitting and review phases, `DebateEngine` also extracts LaTeX/dimensional ex
 Before the literature phase, `MTFOrchestrator._classify_domains()` calls `route_protocol` and `route_skill` with the phenomenon description, parses known GPD domain names from the responses, and overwrites `config.physics_domains` for the run (ephemeral — no persistence). Falls back to the configured default if no domains are detected.
 
 Controlled by:
-- `config.auto_detect_domains: bool = True`
-- `config.gpd_domain_detection_max_domains: int = 4`
+- `config.auto_detect_domains: bool = False`
+- `config.gpd_domain_detection_max_domains: int = 3`
 
 The detected domains (or fallback notice) are written to `MemoryKind.DOMAIN_CLASSIFICATION` as an audit trail.
 
@@ -84,8 +84,8 @@ config = MTFConfig(
     enable_gpd_mcp=True,
     physics_domains=["condensed_matter", "qft"],
     # Domain auto-detection
-    auto_detect_domains=True,
-    gpd_domain_detection_max_domains=4,
+    auto_detect_domains=False,
+    gpd_domain_detection_max_domains=3,
     # Literature plausibility screen
     literature_plausibility_screen=True,
     auto_reject_physics_failures=False,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -141,7 +141,7 @@ Before the first fan-out, three setup steps run once:
    names from the responses, and overwrites `config.physics_domains` for the run (ephemeral —
    no persistence). Falls back to the configured default if no domains are detected. The
    detected domains (or fallback notice) are stored as `DOMAIN_CLASSIFICATION` for audit.
-   Controlled by `config.auto_detect_domains` (default `True`).
+   Controlled by `config.auto_detect_domains` (default `False`).
 
 2. **Convention locking:** The phase calls GPD `subfield_defaults` once per domain in
    `config.physics_domains` and stores each result as `MemoryKind.CONVENTIONS`.  Every subsequent

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -25,6 +25,7 @@ mtf   # interactive mode — you are prompted for everything
 | `--files` | _(none)_ | Input files to digest (images: PNG, JPG, GIF, WebP; documents: PDF) |
 | `--physics-domains` | `condensed_matter` | GPD physics domains (space-separated) |
 | `--no-fitting` | _(off)_ | Skip quantitative fitting; run qualitative hypothesis evaluation instead |
+| `--auto-detect-domains` | _(off)_ | Infer physics domains from the phenomenon text via GPD (opt-in) |
 | `--no-gpd` | _(off)_ | Disable GPD MCP physics verification |
 | `--gpd-servers` | _(all)_ | GPD servers to start |
 | `--no-enhanced-pdf` | _(off)_ | Use single-pass PDF extraction instead of the default two-pass figure analysis |


### PR DESCRIPTION
## Summary

Documentation cleanup following PRs #28 and #29:

- `docs/architecture/gpd.md`: `auto_detect_domains` `True`→`False`, `gpd_domain_detection_max_domains` `4`→`3` (in both the config list and the Python API example)
- `docs/architecture/overview.md`: `auto_detect_domains` default `True`→`False`
- `docs/usage/cli.md`: add `--auto-detect-domains` flag to the reference table

## Test plan

- [ ] All three doc files reflect the correct defaults
- [ ] CLI reference table includes `--auto-detect-domains`

🤖 Generated with [Claude Code](https://claude.com/claude-code)