### PR TITLE
fix: preserve GUI analysis state across browser refreshes

### DIFF
--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -11,11 +11,22 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+from mtf.interface import HumanInterface
+
+# ---------------------------------------------------------------------------
+# Module-level session store — survives browser refreshes
+# ---------------------------------------------------------------------------
+# Streamlit session_state is reset on a full page refresh (F5 / reload).
+# We keep a single-slot global mirror of the orchestrator's mutable state so
+# that a refreshed tab can reconnect to a still-running analysis.
+#
+# Keys:  ui_queue, thread, messages, pending, running, finished,
+#        final_report, error, tmp_dir
+_live_session: dict[str, Any] = {}
+
 # ---------------------------------------------------------------------------
 # HumanInterface implementation
 # ---------------------------------------------------------------------------
-
-from mtf.interface import HumanInterface
 
 _REPLY_TIMEOUT = 3600.0  # 1 hour — abandon wait if browser tab was closed
 
@@ -97,6 +108,21 @@ def _streamlit_app() -> None:
     st.caption("Multi-agent AI system for experimental physicists")
 
     ss = st.session_state
+
+    # ------------------------------------------------------------------
+    # Reconnect to a live session after a browser refresh
+    # ------------------------------------------------------------------
+    # On a full page reload st.session_state is blank. If the orchestrator
+    # is still running (or finished) we restore its state so the user can
+    # continue without losing progress.
+    if not ss.get("_initialised") and _live_session:
+        thread: threading.Thread | None = _live_session.get("thread")
+        if thread is not None and (thread.is_alive() or _live_session.get("finished")):
+            for k, v in _live_session.items():
+                setattr(ss, k, v)
+            ss._initialised = True
+    elif not ss.get("_initialised"):
+        ss._initialised = True
 
     # ------------------------------------------------------------------
     # Sidebar — configuration
@@ -238,6 +264,20 @@ def _streamlit_app() -> None:
             ss.final_report = None
             ss.error = None
             ss.tmp_dir = tmp_dir
+            ss._initialised = True
+            # Persist in the module-level store so a browser refresh can
+            # reconnect to this run without losing progress.
+            _live_session.update(
+                running=True,
+                finished=False,
+                ui_queue=ui_queue,
+                thread=thread,
+                messages=ss.messages,  # shared list reference
+                pending=None,
+                final_report=None,
+                error=None,
+                tmp_dir=tmp_dir,
+            )
             st.rerun()
         return
 
@@ -256,30 +296,35 @@ def _streamlit_app() -> None:
             kind = msg[0]
             if kind == "show":
                 _, content, title = msg
-                ss.messages = ss.get("messages", []) + [
-                    {"type": "show", "content": content, "title": title or "MTF"}
-                ]
+                new_msg = {"type": "show", "content": content, "title": title or "MTF"}
+                ss.messages = ss.get("messages", []) + [new_msg]
+                _live_session["messages"] = ss.messages
             elif kind in ("ask", "confirm"):
                 _, prompt, reply_q = msg
                 ss.pending = {"type": kind, "prompt": prompt, "reply_q": reply_q}
+                _live_session["pending"] = ss.pending
                 break  # wait for user response before draining further
             elif kind == "done":
                 _, report, _ = msg
                 ss.final_report = report
                 ss.running = False
                 ss.finished = True
+                _live_session.update(final_report=report, running=False, finished=True)
                 if tmp_dir := ss.get("tmp_dir"):
                     tmp_dir.cleanup()
                     ss.tmp_dir = None
+                    _live_session["tmp_dir"] = None
                 break
             elif kind == "error":
                 _, tb, _ = msg
                 ss.error = tb
                 ss.running = False
                 ss.finished = True
+                _live_session.update(error=tb, running=False, finished=True)
                 if tmp_dir := ss.get("tmp_dir"):
                     tmp_dir.cleanup()
                     ss.tmp_dir = None
+                    _live_session["tmp_dir"] = None
                 break
 
     # Render accumulated show() messages
@@ -301,6 +346,7 @@ def _streamlit_app() -> None:
                 if st.form_submit_button("Submit"):
                     pending["reply_q"].put(user_text)
                     ss.pending = None
+                    _live_session["pending"] = None
                     st.rerun()
 
         elif pending["type"] == "confirm":
@@ -310,11 +356,13 @@ def _streamlit_app() -> None:
                 if st.button("✅ Approve", type="primary"):
                     pending["reply_q"].put(True)
                     ss.pending = None
+                    _live_session["pending"] = None
                     st.rerun()
             with col2:
                 if st.button("✏️ Request Changes"):
                     pending["reply_q"].put(False)
                     ss.pending = None
+                    _live_session["pending"] = None
                     st.rerun()
 
     # Poll while running with no pending interaction
@@ -345,8 +393,9 @@ def _streamlit_app() -> None:
             if tmp_dir := ss.get("tmp_dir"):
                 tmp_dir.cleanup()
             for key in ["running", "finished", "ui_queue", "thread", "messages",
-                        "pending", "final_report", "error", "tmp_dir"]:
+                        "pending", "final_report", "error", "tmp_dir", "_initialised"]:
                 ss.pop(key, None)
+            _live_session.clear()
             st.rerun()
 
 

--- a/mtf/gui.py
+++ b/mtf/gui.py
@@ -120,7 +120,10 @@ def _streamlit_app() -> None:
         if thread is not None and (thread.is_alive() or _live_session.get("finished")):
             for k, v in _live_session.items():
                 setattr(ss, k, v)
-            ss._initialised = True
+        # Always mark initialised — even when the thread died without setting
+        # finished=True (e.g. event-loop crash before the try/except in
+        # _run_orchestrator) — so this block does not re-run on every poll.
+        ss._initialised = True
     elif not ss.get("_initialised"):
         ss._initialised = True
 
@@ -272,7 +275,7 @@ def _streamlit_app() -> None:
                 finished=False,
                 ui_queue=ui_queue,
                 thread=thread,
-                messages=ss.messages,  # shared list reference
+                messages=ss.messages,
                 pending=None,
                 final_report=None,
                 error=None,


### PR DESCRIPTION
## Summary

- Streamlit `session_state` is wiped on a full page refresh (F5/reload), causing in-progress analyses to appear lost even though the orchestrator thread was still running
- Add a module-level `_live_session` dict that mirrors all mutable orchestrator state (queue, thread, messages, pending, running/finished flags, report, error)
- On each app run, a blank `session_state` is repopulated from `_live_session` so the user seamlessly reconnects to a running or finished analysis

## Behaviour after fix

- All accumulated progress messages are restored after refresh
- Pending `ask`/`confirm` interactions survive refresh — the `reply_q` is preserved so the user can still respond to approval gates
- Final report and error state are restored on completion
- "Start new analysis" clears `_live_session` so the next run starts fresh

## Bug fix (follow-up commit)

If `_live_session` was non-empty but the orchestrator thread died before setting `finished=True` (e.g. event-loop crash before the `try/except` in `_run_orchestrator`), `_initialised` was never set on the session. Neither the inner `if` branch nor the `elif` fired, so the reconnect block re-evaluated on every 0.3s poll rerun indefinitely against a stale dead session. Fixed by moving `ss._initialised = True` outside the inner branch so it always runs when `_live_session` is non-empty.

## Design note

`_live_session` is a module-level singleton — only one analysis at a time across all browser tabs pointing to the same Streamlit server process. Acceptable for this local single-user tool.

## Test plan

- [ ] Start an analysis, wait for at least one progress message, refresh the browser — verify the running view resumes with messages intact
- [ ] Refresh while MTF is waiting at an approval gate — verify the confirm buttons reappear and responding continues the analysis
- [ ] Let an analysis complete, refresh — verify the final report is still shown
- [ ] Click "Start new analysis" after refresh — verify a clean input form appears
- [ ] Kill the orchestrator thread before it sets `finished=True`, refresh — verify the app does not spin in an infinite rerun loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)