### PR TITLE
fix: scope bypassPermissions to LiteratureAgent and sandbox exec builtins

### DIFF
--- a/mtf/agents/base.py
+++ b/mtf/agents/base.py
@@ -25,6 +25,10 @@ _CONVENTION_REMINDER = (
 class BaseAgent:
     """Wraps sdk.query() and injects shared memory context into every prompt."""
 
+    # Subclasses may override to grant broader tool permissions.
+    # Use "bypassPermissions" only for agents whose tools are read-only.
+    _permission_mode: str = "default"
+
     def __init__(
         self,
         agent_id: str,
@@ -61,6 +65,7 @@ class BaseAgent:
             model=self._model,
             system_prompt=self._system_prompt,
             mcp_servers=mcp_servers,
+            permission_mode=self._permission_mode,
         )
         async for chunk in sdk.query(prompt=prompt, options=options):
             if hasattr(chunk, "text"):

--- a/mtf/agents/literature.py
+++ b/mtf/agents/literature.py
@@ -13,9 +13,15 @@ _SYSTEM_PROMPT = """You are an expert theoretical and experimental physicist act
 literature research agent. Your goal is to find relevant prior work that could explain
 the experimental phenomenon provided by the user.
 
+MANDATORY TOOL USE: You MUST call `arxiv_search` and `semantic_scholar_search` multiple
+times with different queries to find actual papers. Do NOT rely on your training knowledge
+for citations — every paper you cite MUST come from a tool call result in this session.
+Fabricating or recalling citations from memory is a critical error.
+
 1. At the start, call `route_protocol` with a description of the phenomenon to
    understand what computation methodology the relevant papers should follow.
-2. Search arxiv and Semantic Scholar thoroughly, prioritising recent, highly-cited work.
+2. Search arxiv and Semantic Scholar thoroughly with at least 3 different queries each,
+   prioritising recent, highly-cited work. Use domain-specific terminology in your queries.
 3. For each proposed hypothesis, call `check_error_classes` with a description of the
    hypothesis to identify the top-15 most likely physics error classes — flag
    error-prone approaches in your report.
@@ -62,6 +68,10 @@ Prefer first-principles hypotheses over phenomenological curve fits. Be precise.
 
 
 class LiteratureAgent(BaseAgent):
+    # arxiv_search and semantic_scholar_search are read-only network calls;
+    # bypass permission prompts so the agent can search without interruption.
+    _permission_mode = "bypassPermissions"
+
     def __init__(
         self,
         agent_id: str,

--- a/mtf/phases/literature_phase.py
+++ b/mtf/phases/literature_phase.py
@@ -145,6 +145,7 @@ async def run_literature_phase(
                 model=config.literature_model,
                 memory=memory,
                 gpd_tools=gpd_tools,
+                config=config,
             )
             for i in range(config.n_literature)
         ]

--- a/mtf/tools/fitting_tools.py
+++ b/mtf/tools/fitting_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import functools
 import textwrap
 import traceback
@@ -10,6 +11,44 @@ from typing import Any
 import numpy as np
 from lmfit import Model, Parameters, minimize as _real_minimize
 from scipy import optimize, stats
+
+# Modules that fitting code is allowed to import.  Anything outside this set
+# raises ImportError so the generated code cannot reach os, subprocess, socket, etc.
+_ALLOWED_IMPORTS = frozenset({
+    "numpy", "np", "lmfit", "scipy", "scipy.optimize", "scipy.stats",
+    "math", "cmath", "functools", "itertools", "collections",
+})
+
+
+def _make_restricted_import(real_import: Any) -> Any:
+    """Return an __import__ that allows only _ALLOWED_IMPORTS."""
+    def _import(name: str, *args: Any, **kwargs: Any) -> Any:
+        top = name.split(".")[0]
+        if top not in _ALLOWED_IMPORTS and name not in _ALLOWED_IMPORTS:
+            raise ImportError(
+                f"Import of '{name}' is not permitted in fitting code. "
+                f"Allowed: {sorted(_ALLOWED_IMPORTS)}"
+            )
+        return real_import(name, *args, **kwargs)
+    return _import
+
+
+_SAFE_BUILTINS: dict[str, Any] = {
+    k: getattr(builtins, k)
+    for k in (
+        "abs", "all", "any", "bool", "bytes", "callable", "chr", "complex",
+        "dict", "divmod", "enumerate", "filter", "float", "format",
+        "frozenset", "getattr", "hasattr", "hash", "int", "isinstance",
+        "issubclass", "iter", "len", "list", "map", "max", "min", "next",
+        "object", "ord", "pow", "print", "range", "repr", "reversed",
+        "round", "set", "slice", "sorted", "str", "sum", "tuple", "type",
+        "zip", "NotImplemented", "Ellipsis", "None", "True", "False",
+        "ArithmeticError", "Exception", "IndexError", "KeyError",
+        "NameError", "RuntimeError", "StopIteration", "TypeError",
+        "ValueError", "ZeroDivisionError", "ImportError",
+    )
+}
+_SAFE_BUILTINS["__import__"] = _make_restricted_import(builtins.__import__)
 
 
 def _make_sentinel_minimize(called_flag: list[bool]):
@@ -106,6 +145,7 @@ def run_fitting_code(code: str, data: dict[str, Any], integrity_check: bool = Tr
     if integrity_check:
         optimizer_called: list[bool] = [False]
         namespace: dict[str, Any] = {
+            "__builtins__": _SAFE_BUILTINS,
             "np": np,
             "numpy": np,
             "Model": _make_sentinel_model(optimizer_called),
@@ -118,6 +158,7 @@ def run_fitting_code(code: str, data: dict[str, Any], integrity_check: bool = Tr
         }
     else:
         namespace = {
+            "__builtins__": _SAFE_BUILTINS,
             "np": np,
             "numpy": np,
             "Model": Model,


### PR DESCRIPTION
## Summary

- **`BaseAgent`**: `permission_mode` is now driven by a `_permission_mode` class attribute (default `"default"`). Subclasses opt in by overriding it rather than having it hardcoded globally.
- **`LiteratureAgent`**: sets `_permission_mode = "bypassPermissions"` — its tools (`arxiv_search`, `semantic_scholar_search`) are read-only network calls, so no permission prompts are needed. All other agents (`FittingAgent`, `ReviewerAgent`, etc.) keep `"default"`.
- **`LiteratureAgent` system prompt**: added a `MANDATORY TOOL USE` block that forbids training-knowledge citations and requires ≥3 distinct queries per tool with domain-specific terminology.
- **`literature_phase`**: fixed missing `config=config` so `citation_verification` settings propagate to agents.
- **`fitting_tools`**: replaced the bare `exec()` namespace with `_SAFE_BUILTINS` — a whitelist of safe Python builtins plus a restricted `__import__` that allows `numpy/lmfit/scipy` but blocks `os`, `subprocess`, `socket`, etc. This closes the `__builtins__` escape path identified in the PR review where agent-generated fitting code could have called `import os; os.system(...)`.

## Test plan

- [x] `pytest tests/test_fitting_tools.py` — all passing, including the legitimate-fit test that uses `import numpy` inside generated code
- [x] `pytest tests/test_memory.py tests/test_debate.py tests/test_phases.py` — all passing
- [ ] Manual run: confirm literature reports now cite papers found via arxiv/Semantic Scholar tool calls rather than training memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)